### PR TITLE
Update to v0.1.2

### DIFF
--- a/trident-java/README.md
+++ b/trident-java/README.md
@@ -8,7 +8,7 @@ Trident-Java document: https://developers.tron.network/docs/trident-java
 
 Due to safety concerns, trident-java will no longer upload packaged files to maven. Please clone the code from GitHub and do the packaging. 
 
-Trident-java is compiled with java version 13.0.2+8 and gradle 5.6.4.
+Trident-java is compiled with java version 1.8.0_231 and gradle 5.6.4.
 
 ## How to use
 
@@ -43,19 +43,19 @@ dependencies {
 <dependency>
   <groupId>org.tron.trident</groupId>
   <artifactId>abi</artifactId>
-  <version>0.1.1</version>
+  <version>0.1.2</version>
   <type>pom</type>
 </dependency>
 <dependency>
   <groupId>org.tron.trident</groupId>
   <artifactId>utils</artifactId>
-  <version>0.1.1</version>
+  <version>0.1.2</version>
   <type>pom</type>
 </dependency>
 <dependency>
   <groupId>org.tron.trident</groupId>
   <artifactId>core</artifactId>
-  <version>0.1.1</version>
+  <version>0.1.2</version>
   <type>pom</type>
 </dependency>
 ```

--- a/trident-java/abi/build.gradle
+++ b/trident-java/abi/build.gradle
@@ -1,35 +1,11 @@
 plugins {
-    id 'com.jfrog.bintray'
+    
 }
 
 description 'TRON Application Binary Interface (ABI) for working with smart contracts'
 
 dependencies {
     implementation project(':utils')
-}
-
-bintray {
-    user = System.getenv('BINTRAY_USER_TRIDENT')
-    key = System.getenv('BINTRAY_KEY_TRIDENT')
-
-    configurations = ['archives']
-
-    pkg {
-        repo = 'trident'
-        name = 'abi'
-        desc = description
-        websiteUrl = 'https://github.com/tronprotocol/trident'
-        vcsUrl = 'https://github.com/tronprotocol/trident.git'
-        licenses = ['Apache-2.0']
-        publish = true
-        publicDownloadNumbers = true
-        version {
-            afterEvaluate {
-                name = "${project.version}"
-                released = new Date()
-            }
-        }
-    }
 }
 
 tasks.create('buildLib', Jar) {

--- a/trident-java/build.gradle
+++ b/trident-java/build.gradle
@@ -1,7 +1,5 @@
 plugins {
     id 'java-library'
-    id 'com.jfrog.bintray' apply false
-    id 'signing'
 }
 
 ext {
@@ -10,7 +8,7 @@ ext {
 }
 
 allprojects {
-    version '0.1.1'
+    version '0.1.2'
     group = 'org.tron.trident'
 
     repositories {

--- a/trident-java/core/build.gradle
+++ b/trident-java/core/build.gradle
@@ -1,5 +1,4 @@
 plugins {
-    id 'com.jfrog.bintray'
     id 'com.google.protobuf' version '0.8.12'
 }
 
@@ -40,26 +39,3 @@ protobuf {
     generatedFilesBaseDir = "$projectDir/src"
 }
 
-bintray {
-    user = System.getenv('BINTRAY_USER_TRIDENT')
-    key = System.getenv('BINTRAY_KEY_TRIDENT')
-
-    configurations = ['archives']
-
-    pkg {
-        repo = 'trident'
-        name = 'core'
-        desc = description
-        websiteUrl = 'https://github.com/tronprotocol/trident'
-        vcsUrl = 'https://github.com/tronprotocol/trident.git'
-        licenses = ['Apache-2.0']
-        publish = true
-        publicDownloadNumbers = true
-        version {
-            afterEvaluate {
-                name = "${project.version}"
-                released = new Date()
-            }
-        }
-    }
-}

--- a/trident-java/core/src/main/java/org/tron/trident/core/ApiWrapper.java
+++ b/trident-java/core/src/main/java/org/tron/trident/core/ApiWrapper.java
@@ -8,7 +8,7 @@ package org.tron.trident.core;
  * {@link #broadcastTransaction}, {@link #signTransaction} and other transaction related
  * operations can be done via a {@code ApiWrapper} object.</p>
  *
- * @since jdk13.0.2+8
+ * @since java version 1.8.0_231
  * @see org.tron.trident.core.contract.Contract
  * @see org.tron.trident.proto.Chain.Transaction
  * @see org.tron.trident.proto.Contract
@@ -154,7 +154,7 @@ public class ApiWrapper {
      * @param apiKey this function works with TronGrid, an API key is required.
      * @return a ApiWrapper object
      */
-    @Deprecated(since = "0.2.0", forRemoval = true)
+    @Deprecated
     public static ApiWrapper ofMainnet(String hexPrivateKey) {
         return new ApiWrapper("grpc.trongrid.io:50051", "grpc.trongrid.io:50052", hexPrivateKey);
     }

--- a/trident-java/core/src/main/java/org/tron/trident/core/contract/Trc20Contract.java
+++ b/trident-java/core/src/main/java/org/tron/trident/core/contract/Trc20Contract.java
@@ -33,11 +33,9 @@ import java.util.Arrays;
 import java.util.Collections;
 
 public class Trc20Contract extends Contract {
-    protected int decimals;
 
     public Trc20Contract(Contract cntr, String ownerAddr, ApiWrapper wrapper) {
         super(cntr, ownerAddr, wrapper);
-        decimals = decimals().intValue();
     }
 
     /**
@@ -141,15 +139,16 @@ public class Trc20Contract extends Contract {
        * 
        * @param destAddr The address to receive the token
        * @param amount The transfer amount
+       * @param power The power number of 10 that the transfer amount multiplied by
        * @param memo The transaction memo
        * @param feeLimit The energy fee limit
        * @return Transaction hash
        */
-      public String transfer(String destAddr, long amount, 
+      public String transfer(String destAddr, long amount, int power,
              String memo, long feeLimit) {
         Function transfer = new Function("transfer",
                 Arrays.asList(new Address(destAddr),
-                        new Uint256(BigInteger.valueOf(amount).multiply(BigInteger.valueOf(10).pow(decimals)))),
+                        new Uint256(BigInteger.valueOf(amount).multiply(BigInteger.valueOf(10).pow(power)))),
                 Arrays.asList(new TypeReference<Bool>() {}));
 
         TransactionBuilder builder = wrapper.triggerCall(Base58Check.bytesToBase58(ownerAddr.toByteArray()), 
@@ -171,15 +170,16 @@ public class Trc20Contract extends Contract {
        * @param fromAddr The address who sends tokens (or the address to withdraw from)
        * @param destAddr The address to receive the token
        * @param amount The transfer amount
+       * @param power The power number of 10 that the transfer amount multiplied by
        * @param memo The transaction memo
        * @param feeLimit The energy fee limit
        * @return Transaction hash
        */
-      public String transferFrom(String fromAddr, String destAddr, long amount, 
+      public String transferFrom(String fromAddr, String destAddr, long amount, int power,
              String memo, long feeLimit) {
         Function transferFrom = new Function("transferFrom",
                 Arrays.asList(new Address(fromAddr) ,new Address(destAddr),
-                        new Uint256(BigInteger.valueOf(amount).multiply(BigInteger.valueOf(10).pow(decimals)))),
+                        new Uint256(BigInteger.valueOf(amount).multiply(BigInteger.valueOf(10).pow(power)))),
                 Arrays.asList(new TypeReference<Bool>() {}));
 
         TransactionBuilder builder = wrapper.triggerCall(Base58Check.bytesToBase58(ownerAddr.toByteArray()), 
@@ -199,15 +199,16 @@ public class Trc20Contract extends Contract {
        * 
        * @param spender The address who is allowed to withdraw.
        * @param amount The amount allowed to withdraw.
+       * @param power The power number of 10 that the transfer amount multiplied by
        * @param memo The transaction memo
        * @param feeLimit The energy fee limit
        * @return Transaction hash
        */
-      public String approve(String spender ,long amount, 
+      public String approve(String spender ,long amount, int power,
              String memo, long feeLimit) {
         Function approve = new Function("approve",
                 Arrays.asList(new Address(spender) ,
-                        new Uint256(BigInteger.valueOf(amount).multiply(BigInteger.valueOf(10).pow(decimals)))),
+                        new Uint256(BigInteger.valueOf(amount).multiply(BigInteger.valueOf(10).pow(power)))),
                 Arrays.asList(new TypeReference<Bool>() {}));
 
                 TransactionBuilder builder = wrapper.triggerCall(Base58Check.bytesToBase58(ownerAddr.toByteArray()), 

--- a/trident-java/core/src/main/java/org/tron/trident/core/transaction/TransactionBuilder.java
+++ b/trident-java/core/src/main/java/org/tron/trident/core/transaction/TransactionBuilder.java
@@ -8,7 +8,7 @@ package org.tron.trident.core.transaction;
  * transaction, for setting attributes values like {@link #setFeeLimit}, {@link
  * #setMemo}, Etc.</p>
  *
- * @since jdk13.0.2+8
+ * @since java version 1.8.0_231
  * @see org.tron.trident.proto.Chain.Transaction;
  */
 

--- a/trident-java/settings.gradle
+++ b/trident-java/settings.gradle
@@ -1,7 +1,5 @@
 pluginManagement {
-  plugins {
-    id 'com.jfrog.bintray' version '1.8.5'
-  }
+
 }
 
 rootProject.name = 'trident'

--- a/trident-java/utils/build.gradle
+++ b/trident-java/utils/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.jfrog.bintray'
+
 }
 
 description 'Minimal set of trident utility classes'
@@ -11,26 +11,3 @@ dependencies {
     implementation "org.bouncycastle:bcprov-jdk15on:1.68"
 }
 
-bintray {
-    user = System.getenv('BINTRAY_USER_TRIDENT')
-    key = System.getenv('BINTRAY_KEY_TRIDENT')
-
-    configurations = ['archives']
-
-    pkg {
-        repo = 'trident'
-        name = 'utils'
-        desc = description
-        websiteUrl = 'https://github.com/tronprotocol/trident'
-        vcsUrl = 'https://github.com/tronprotocol/trident.git'
-        licenses = ['Apache-2.0']
-        publish = true
-        publicDownloadNumbers = true
-        version {
-            afterEvaluate {
-                name = "${project.version}"
-                released = new Date()
-            }
-        }
-    }
-}


### PR DESCRIPTION
Remove unused Bintray related codes.

Remove the use of the JDK11 feature. Now the project can be compiled in JDK8.

Remove the hardcoded decimal in transfer/transferFrom/approve in Trc20Contract. Now non-integer transfers and approvals can be made.

Increase version to 0.1.2. Modified build.gradle and examples in README.