### PR TITLE
bugfix: fix Mac M1 M2 support 增加对苹果m1的支持

### DIFF
--- a/trident-java/core/build.gradle
+++ b/trident-java/core/build.gradle
@@ -24,11 +24,19 @@ dependencies {
 
 protobuf {
     protoc {
-        artifact = 'com.google.protobuf:protoc:3.12.0'
+        if (osdetector.os == "osx") {
+            artifact = 'com.google.protobuf:protoc:3.12.0:osx-x86_64'
+        } else {
+            artifact = 'com.google.protobuf:protoc:3.12.0'
+        }
     }
     plugins {
         grpc {
-            artifact = 'io.grpc:protoc-gen-grpc-java:1.31.0'
+            if (osdetector.os == "osx") {
+                artifact = 'io.grpc:protoc-gen-grpc-java:1.31.0:osx-x86_64'
+            } else {
+                artifact = 'io.grpc:protoc-gen-grpc-java:1.31.0'
+            }
         }
     }
     generateProtoTasks {


### PR DESCRIPTION
Fix 
Execution failed for task ':core:generateProto'.
> Could not resolve all files for configuration ':core:protobufToolsLocator_grpc'.
   > Could not find protoc-gen-grpc-java-osx-aarch_64.exe (io.grpc:protoc-gen-grpc-java:1.31.0).
     Searched in the following locations:
         https://repo.maven.apache.org/maven2/io/grpc/protoc-gen-grpc-java/1.31.0/protoc-gen-grpc-java-1.31.0-osx-aarch_64.exe
