### PR TITLE
feat(api): deprecate estimateEnergyV2; add new triggerConstantContract

### DIFF
--- a/trident-java/core/src/main/java/org/tron/trident/core/Api.java
+++ b/trident-java/core/src/main/java/org/tron/trident/core/Api.java
@@ -284,10 +284,14 @@ public interface Api {
   Response.EstimateEnergyMessage estimateEnergy(String ownerAddress, String contractAddress,
       Function function);
 
+  @Deprecated
   Response.EstimateEnergyMessage estimateEnergyV2(String ownerAddress, String contractAddress,
       String callData);
 
-  Response.EstimateEnergyMessage estimateEnergyV2(String ownerAddress, String contractAddress,
+  Response.EstimateEnergyMessage estimateEnergy(String ownerAddress,
+      String contractAddress, String callData);
+
+  Response.EstimateEnergyMessage estimateEnergy(String ownerAddress, String contractAddress,
       String callData, long callValue, long tokenValue, String tokenId);
 
   @Deprecated
@@ -301,6 +305,9 @@ public interface Api {
 
   TransactionExtention triggerConstantContract(String ownerAddress, String contractAddress,
       String callData);
+
+  TransactionExtention triggerConstantContract(String ownerAddress, String contractAddress,
+      Function function, long callValue, long tokenValue, String tokenId);
 
   TransactionExtention triggerConstantContract(String ownerAddress, String contractAddress,
       String callData, long callValue, long tokenValue, String tokenId);

--- a/trident-java/core/src/test/java/org/tron/trident/core/ContractTest.java
+++ b/trident-java/core/src/test/java/org/tron/trident/core/ContractTest.java
@@ -210,7 +210,7 @@ class ContractTest extends BaseTest {
         Collections.singletonList(new TypeReference<Uint256>() {
         }));
     String encodedHex = FunctionEncoder.encode(depositFunction);
-    EstimateEnergyMessage estimateEnergyMessage = client.estimateEnergyV2(fromAddr, strx,
+    EstimateEnergyMessage estimateEnergyMessage = client.estimateEnergy(fromAddr, strx,
         encodedHex, 1_000_000L, 0, "");
     //System.out.println(estimateEnergyMessage.getEnergyRequired());
     assertTrue(estimateEnergyMessage.getEnergyRequired() > 0);


### PR DESCRIPTION
**What does this PR do?**

- deprecate api of `estimateEnergyV2`
- add new api `triggerConstantContract` to support `Function` parameter

**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**