### PR TITLE
feat(api): Keep only one function triggerContract with feeLimit

### DIFF
--- a/trident-java/core/src/main/java/org/tron/trident/core/Api.java
+++ b/trident-java/core/src/main/java/org/tron/trident/core/Api.java
@@ -366,6 +366,4 @@ public interface Api {
   TransactionExtention deployContract(String contractName, String abiStr, String bytecode,
       List<Type<?>> constructorParams, long feeLimit, long consumeUserResourcePercent,
       long originEnergyLimit, long callValue, String tokenId, long tokenValue) throws Exception;
-
-  TransactionExtention deployContract(String name, String abiStr, String bytecode) throws Exception;
 }

--- a/trident-java/core/src/main/java/org/tron/trident/core/Api.java
+++ b/trident-java/core/src/main/java/org/tron/trident/core/Api.java
@@ -238,18 +238,6 @@ public interface Api {
   TransactionBuilder triggerCall(String ownerAddress, String contractAddress, Function function);
 
   TransactionExtention triggerContract(String ownerAddress, String contractAddress,
-      Function function) throws Exception;
-
-  TransactionExtention triggerContract(String ownerAddress, String contractAddress,
-      String callData) throws Exception;
-
-  TransactionExtention triggerContract(String ownerAddress, String contractAddress,
-      Function function, long callValue, long tokenValue, String tokenId) throws Exception;
-
-  TransactionExtention triggerContract(String ownerAddress, String contractAddress,
-      String callData, long callValue, long tokenValue, String tokenId) throws Exception;
-
-  TransactionExtention triggerContract(String ownerAddress, String contractAddress,
       String callData, long callValue, long tokenValue, String tokenId, long feeLimit)
       throws Exception;
 

--- a/trident-java/core/src/main/java/org/tron/trident/core/ApiWrapper.java
+++ b/trident-java/core/src/main/java/org/tron/trident/core/ApiWrapper.java
@@ -1957,7 +1957,6 @@ public class ApiWrapper implements Api {
     TriggerSmartContract trigger = buildTrigger(ownerAddress, contractAddress, callData, callValue,
         tokenValue, tokenId);
     return blockingStub.triggerConstantContract(trigger);
-
   }
 
   /**
@@ -2318,14 +2317,16 @@ public class ApiWrapper implements Api {
    */
   private TriggerSmartContract buildTrigger(String ownerAddress, String contractAddress,
       String callData, long callValue, long tokenValue, String tokenId) {
+    if (callValue < 0) {
+      throw new IllegalArgumentException("callValue must be >= 0");
+    }
+    TokenValidator.validateTokenId(tokenId);
     TriggerSmartContract.Builder builder =
         TriggerSmartContract.newBuilder()
             .setOwnerAddress(parseAddress(ownerAddress))
             .setContractAddress(parseAddress(contractAddress))
-            .setData(ByteString.copyFrom(ByteArray.fromHexString(callData)));
-    if (callValue > 0) {
-      builder.setCallValue(callValue);
-    }
+            .setData(ByteString.copyFrom(ByteArray.fromHexString(callData)))
+            .setCallValue(callValue);
     if (tokenId != null && !tokenId.isEmpty()) {
       builder.setCallTokenValue(tokenValue);
       builder.setTokenId(Long.parseLong(tokenId));
@@ -2828,7 +2829,7 @@ public class ApiWrapper implements Api {
       String code, long callValue, long consumeUserResourcePercent, long originEnergyLimit,
       long tokenValue, String tokenId) throws Exception {
     if (callValue < 0) {
-      throw new IllegalException("callValue must be >= 0");
+      throw new IllegalArgumentException("callValue must be >= 0");
     }
     TokenValidator.validateTokenId(tokenId);
     //abi
@@ -2847,7 +2848,7 @@ public class ApiWrapper implements Api {
     CreateSmartContract.Builder createSmartContractBuilder = CreateSmartContract.newBuilder()
         .setOwnerAddress(parseAddress(address))
         .setNewContract(builder.build());
-    if (tokenId != null && !tokenId.equalsIgnoreCase("") && !tokenId.equalsIgnoreCase("#")) {
+    if (tokenId != null && !tokenId.equalsIgnoreCase("")) {
       createSmartContractBuilder.setCallTokenValue(tokenValue)
           .setTokenId(Long.parseLong(tokenId));
     }

--- a/trident-java/core/src/main/java/org/tron/trident/core/ApiWrapper.java
+++ b/trident-java/core/src/main/java/org/tron/trident/core/ApiWrapper.java
@@ -1,10 +1,10 @@
 package org.tron.trident.core;
 
-import static org.tron.trident.core.Constant.CONSUME_USER_RESOURCE_PERCENT;
-import static org.tron.trident.core.Constant.FEE_LIMIT;
 import static org.tron.trident.core.Constant.GRPC_TIMEOUT;
-import static org.tron.trident.core.Constant.ORIGIN_ENERGY_LIMIT;
 import static org.tron.trident.core.Constant.TRANSACTION_DEFAULT_EXPIRATION_TIME;
+import static org.tron.trident.core.utils.TokenValidator.validateCallValue;
+import static org.tron.trident.core.utils.TokenValidator.validateTokenId;
+import static org.tron.trident.core.utils.TokenValidator.validateTokenValue;
 import static org.tron.trident.core.utils.Utils.encodeParameter;
 
 import com.google.protobuf.ByteString;
@@ -42,7 +42,6 @@ import org.tron.trident.core.transaction.TransactionBuilder;
 import org.tron.trident.core.transaction.TransactionCapsule;
 import org.tron.trident.core.utils.ByteArray;
 import org.tron.trident.core.utils.Sha256Hash;
-import org.tron.trident.core.utils.TokenValidator;
 import org.tron.trident.core.utils.Utils;
 import org.tron.trident.proto.Chain.Block;
 import org.tron.trident.proto.Chain.Transaction;
@@ -2317,10 +2316,9 @@ public class ApiWrapper implements Api {
    */
   private TriggerSmartContract buildTrigger(String ownerAddress, String contractAddress,
       String callData, long callValue, long tokenValue, String tokenId) {
-    if (callValue < 0) {
-      throw new IllegalArgumentException("callValue must be >= 0");
-    }
-    TokenValidator.validateTokenId(tokenId);
+    validateCallValue(callValue);
+    validateTokenId(tokenId);
+    validateTokenValue(tokenValue);
     TriggerSmartContract.Builder builder =
         TriggerSmartContract.newBuilder()
             .setOwnerAddress(parseAddress(ownerAddress))
@@ -2745,8 +2743,8 @@ public class ApiWrapper implements Api {
   public TransactionExtention marketSellAsset(String ownerAddress, String sellTokenId,
       long sellTokenQuantity, String buyTokenId, long buyTokenQuantity) throws IllegalException {
     ByteString rawOwner = parseAddress(ownerAddress);
-    TokenValidator.validateTokenId(sellTokenId);
-    TokenValidator.validateTokenId(buyTokenId);
+    validateTokenId(sellTokenId);
+    validateTokenId(buyTokenId);
 
     MarketSellAssetContract marketSellAssetContract = MarketSellAssetContract.newBuilder()
         .setOwnerAddress(rawOwner)
@@ -2828,10 +2826,9 @@ public class ApiWrapper implements Api {
   public CreateSmartContract createSmartContract(String contractName, String address, String ABI,
       String code, long callValue, long consumeUserResourcePercent, long originEnergyLimit,
       long tokenValue, String tokenId) throws Exception {
-    if (callValue < 0) {
-      throw new IllegalArgumentException("callValue must be >= 0");
-    }
-    TokenValidator.validateTokenId(tokenId);
+    validateCallValue(callValue);
+    validateTokenId(tokenId);
+    validateTokenValue(tokenValue);
     //abi
     SmartContract.ABI.Builder abiBuilder = SmartContract.ABI.newBuilder();
     Contract.loadAbiFromJson(ABI, abiBuilder);
@@ -2906,9 +2903,9 @@ public class ApiWrapper implements Api {
       long feeLimit, long consumeUserResourcePercent, long originEnergyLimit, long callValue,
       String tokenId, long tokenValue)
       throws Exception {
-
-    TokenValidator.validateTokenId(tokenId);
-
+    validateCallValue(callValue);
+    validateTokenId(tokenId);
+    validateTokenValue(tokenValue);
     if (constructorParams != null && !constructorParams.isEmpty()) {
       ByteString constructorParamsByteString = encodeParameter(constructorParams);
       ByteString newByteCode = ByteString.copyFrom(ByteArray.fromHexString(bytecode))

--- a/trident-java/core/src/main/java/org/tron/trident/core/ApiWrapper.java
+++ b/trident-java/core/src/main/java/org/tron/trident/core/ApiWrapper.java
@@ -471,8 +471,8 @@ public class ApiWrapper implements Api {
     try {
       TransactionCapsule trx = createTransaction(request, contractType);
 
-      if (contractType != Transaction.Contract.ContractType.CreateSmartContract &&
-          contractType != ContractType.TriggerSmartContract) {
+      if (contractType != Transaction.Contract.ContractType.CreateSmartContract
+          && contractType != ContractType.TriggerSmartContract) {
         trxExtBuilder.setTransaction(trx.getTransaction());
       } else {
         if (feeLimit <= 0L) {
@@ -1921,7 +1921,7 @@ public class ApiWrapper implements Api {
   }
 
   /**
-   * @see #triggerContract(String, String, String)
+   * @see #triggerConstantContract(String, String, String)
    */
   @Override
   public TransactionExtention triggerConstantContract(String ownerAddress, String contractAddress,
@@ -1933,7 +1933,6 @@ public class ApiWrapper implements Api {
   /**
    * @see #triggerConstantContract(String, String, String, long, long, String)
    */
-
   @Override
   public TransactionExtention triggerConstantContract(String ownerAddress, String contractAddress,
       String callData) {
@@ -1998,66 +1997,6 @@ public class ApiWrapper implements Api {
   }
 
   /**
-   * make a TriggerSmartContract using default feeLimit (150 TRX), - no broadcasting. it can be broadcast later.
-   *
-   * @param ownerAddress the current caller
-   * @param contractAddress smart contract address
-   * @param function contract function
-   * @return TransactionExtention
-   * @throws IllegalException if fail
-   */
-  @Override
-  public TransactionExtention triggerContract(String ownerAddress, String contractAddress,
-      Function function) throws Exception {
-    String encodedHex = FunctionEncoder.encode(function);
-    return triggerContract(ownerAddress, contractAddress, encodedHex, 0L, 0L, null, FEE_LIMIT);
-  }
-
-  /**
-   * make a TriggerSmartContract using default feeLimit (150 TRX), - no broadcasting. it can be broadcast later.
-   *
-   * @see #triggerContract(String, String, String, long, long, String, long)
-   */
-  @Override
-  public TransactionExtention triggerContract(String ownerAddress, String contractAddress,
-      String callData) throws Exception {
-    return triggerContract(ownerAddress, contractAddress, callData, 0L, 0L, null, FEE_LIMIT);
-  }
-
-  /**
-   * make a TriggerSmartContract using default feeLimit (150 TRX), - no broadcasting. it can be broadcast later.
-   *
-   * @param ownerAddress the current caller
-   * @param contractAddress smart contract address
-   * @param function the contract function to call
-   * @param callValue the amount of sun send to contract
-   * @param tokenValue the amount of tokenId
-   * @param tokenId tokenId
-   * @return TransactionExtention
-   * @throws Exception if fail
-   */
-  @Override
-  public TransactionExtention triggerContract(String ownerAddress, String contractAddress,
-      Function function, long callValue, long tokenValue, String tokenId) throws Exception {
-    String encodedHex = FunctionEncoder.encode(function);
-    return triggerContract(ownerAddress, contractAddress, encodedHex, callValue, tokenValue,
-        tokenId, FEE_LIMIT);
-  }
-
-  /**
-   * make a TriggerSmartContract using default feeLimit (150 TRX), - no broadcasting. it can be broadcast later.
-   *
-   * @see #triggerContract(String, String, String, long, long, String, long)
-   */
-  @Override
-  public TransactionExtention triggerContract(String ownerAddress, String contractAddress,
-      String callData, long callValue, long tokenValue, String tokenId) throws Exception {
-
-    return triggerContract(ownerAddress, contractAddress, callData, callValue, tokenValue, tokenId,
-        FEE_LIMIT);
-  }
-
-  /**
    * make a TriggerSmartContract, - no broadcasting. it can be broadcast later.
    *
    * @param ownerAddress the current caller
@@ -2078,7 +2017,6 @@ public class ApiWrapper implements Api {
         callValue, tokenValue, tokenId);
 
     return createTransactionExtention(trigger, ContractType.TriggerSmartContract, feeLimit);
-
   }
 
   /**
@@ -2985,6 +2923,7 @@ public class ApiWrapper implements Api {
   }
 
   /**
+   * Deploy a smart contract using default feeLimit (150 TRX) - no broadcasting
    * @see #deployContract(String, String, String, List, long, long, long, long, String, long)
    */
   @Override

--- a/trident-java/core/src/main/java/org/tron/trident/core/ApiWrapper.java
+++ b/trident-java/core/src/main/java/org/tron/trident/core/ApiWrapper.java
@@ -2010,7 +2010,7 @@ public class ApiWrapper implements Api {
   public TransactionExtention triggerContract(String ownerAddress, String contractAddress,
       Function function) throws Exception {
     String encodedHex = FunctionEncoder.encode(function);
-    return triggerContract(ownerAddress, contractAddress, encodedHex);
+    return triggerContract(ownerAddress, contractAddress, encodedHex, 0L, 0L, null, FEE_LIMIT);
   }
 
   /**

--- a/trident-java/core/src/main/java/org/tron/trident/core/ApiWrapper.java
+++ b/trident-java/core/src/main/java/org/tron/trident/core/ApiWrapper.java
@@ -2827,7 +2827,10 @@ public class ApiWrapper implements Api {
   public CreateSmartContract createSmartContract(String contractName, String address, String ABI,
       String code, long callValue, long consumeUserResourcePercent, long originEnergyLimit,
       long tokenValue, String tokenId) throws Exception {
-
+    if (callValue < 0) {
+      throw new IllegalException("callValue must be >= 0");
+    }
+    TokenValidator.validateTokenId(tokenId);
     //abi
     SmartContract.ABI.Builder abiBuilder = SmartContract.ABI.newBuilder();
     Contract.loadAbiFromJson(ABI, abiBuilder);
@@ -2838,12 +2841,9 @@ public class ApiWrapper implements Api {
         .setOriginAddress(parseAddress(address))
         .setAbi(abi)
         .setConsumeUserResourcePercent(consumeUserResourcePercent)
-        .setOriginEnergyLimit(originEnergyLimit);
-    if (callValue != 0) {
-      builder.setCallValue(callValue);
-    }
-
-    builder.setBytecode(ByteString.copyFrom(ByteArray.fromHexString(code)));
+        .setOriginEnergyLimit(originEnergyLimit)
+        .setCallValue(callValue)
+        .setBytecode(ByteString.copyFrom(ByteArray.fromHexString(code)));
     CreateSmartContract.Builder createSmartContractBuilder = CreateSmartContract.newBuilder()
         .setOwnerAddress(parseAddress(address))
         .setNewContract(builder.build());
@@ -2920,26 +2920,5 @@ public class ApiWrapper implements Api {
 
     return createTransactionExtention(createSmartContract,
         ContractType.CreateSmartContract, feeLimit);
-  }
-
-  /**
-   * Deploy a smart contract using default feeLimit (150 TRX) - no broadcasting
-   * @see #deployContract(String, String, String, List, long, long, long, long, String, long)
-   */
-  @Override
-  public TransactionExtention deployContract(String name, String abiStr,
-      String bytecode) throws Exception {
-    return deployContract(
-        name,
-        abiStr,
-        bytecode,
-        null,
-        FEE_LIMIT,
-        CONSUME_USER_RESOURCE_PERCENT,
-        ORIGIN_ENERGY_LIMIT,
-        0L,
-        null,
-        0L
-    );
   }
 }

--- a/trident-java/core/src/main/java/org/tron/trident/core/Constant.java
+++ b/trident-java/core/src/main/java/org/tron/trident/core/Constant.java
@@ -13,16 +13,9 @@ public final class Constant {
   public static final String FULLNODE_NILE = "grpc.nile.trongrid.io:50051";
   public static final String FULLNODE_NILE_SOLIDITY = "grpc.nile.trongrid.io:50061";
 
-
   public static final long TRANSACTION_DEFAULT_EXPIRATION_TIME = 60 * 1_000L; //60 seconds
 
   public static final long GRPC_TIMEOUT = 30 * 1_000L; //30 seconds
-
-  public static final long FEE_LIMIT = 150_000_000L; //150 TRX
-
-  public static final long CONSUME_USER_RESOURCE_PERCENT = 100L;
-
-  public static final long ORIGIN_ENERGY_LIMIT = 100_000_000L;
 
   public static final String TRX_SYMBOL = "_";
 

--- a/trident-java/core/src/main/java/org/tron/trident/core/utils/TokenValidator.java
+++ b/trident-java/core/src/main/java/org/tron/trident/core/utils/TokenValidator.java
@@ -5,6 +5,13 @@ import static org.tron.trident.core.Constant.TRX_SYMBOL;
 import org.tron.trident.utils.Numeric;
 
 public class TokenValidator {
+
+  public static void validateCallValue(long callValue) {
+    if (callValue < 0) {
+      throw new IllegalArgumentException("callValue must be >= 0");
+    }
+  }
+
   /**
    * Validates the general format and value of a token ID
    *
@@ -30,7 +37,12 @@ public class TokenValidator {
     if (tokenValue < 1000000L) {
       throw new IllegalArgumentException("TRC10 token ID must ge 1000000");
     }
+  }
 
+  public static void validateTokenValue(long tokenValue) {
+    if (tokenValue < 0) {
+      throw new IllegalArgumentException("tokenValue must be >= 0");
+    }
   }
 
 }

--- a/trident-java/core/src/test/java/org/tron/trident/core/ContractTest.java
+++ b/trident-java/core/src/test/java/org/tron/trident/core/ContractTest.java
@@ -71,7 +71,7 @@ class ContractTest extends BaseTest {
             + "7a7a72305820b24fc247fdaf3644b3c4c94fcee380aa610ed83415061ff9e65d7fa94a5a50a00029";
 
     TransactionExtention transactionExtention = client.deployContract("testDeployContract", abiStr,
-        bytecode, null, Constant.FEE_LIMIT, 0, 1_000_000L, 0, null, 0);
+        bytecode, null, 150_000_000L, 0, 1_000_000L, 0, null, 0);
 
     Transaction transaction = client.signTransaction(transactionExtention.getTransaction());
     String txId = client.broadcastTransaction(transaction);
@@ -174,7 +174,7 @@ class ContractTest extends BaseTest {
         }));
     String encodedHex = FunctionEncoder.encode(trc20Transfer);
     TransactionExtention transactionExtention = client.triggerContract(fromAddr, usdtAddr,
-        encodedHex, 0, 0, null, Constant.FEE_LIMIT);
+        encodedHex, 0, 0, null, 150_000_000L);
 
     Transaction signedTxn = client.signTransaction(transactionExtention);
 

--- a/trident-java/core/src/test/java/org/tron/trident/core/ContractTest.java
+++ b/trident-java/core/src/test/java/org/tron/trident/core/ContractTest.java
@@ -71,7 +71,7 @@ class ContractTest extends BaseTest {
             + "7a7a72305820b24fc247fdaf3644b3c4c94fcee380aa610ed83415061ff9e65d7fa94a5a50a00029";
 
     TransactionExtention transactionExtention = client.deployContract("testDeployContract", abiStr,
-        bytecode, null, Constant.FEE_LIMIT, 0, 1_000_000L, 0, null , 0);
+        bytecode, null, Constant.FEE_LIMIT, 0, 1_000_000L, 0, null, 0);
 
     Transaction transaction = client.signTransaction(transactionExtention.getTransaction());
     String txId = client.broadcastTransaction(transaction);
@@ -316,6 +316,20 @@ class ContractTest extends BaseTest {
         Collections.singletonList(new TypeReference<Bool>() {
         }));
     String encodedHex = FunctionEncoder.encode(trc20Transfer);
+    try {
+      client.triggerConstantContract(fromAddr, usdtAddr,
+          encodedHex, -1L, 0L, null);
+      assert false;
+    } catch (Exception e) {
+      assert e instanceof IllegalArgumentException;
+    }
+    try {
+      client.triggerConstantContract(fromAddr, usdtAddr,
+          encodedHex, 0L, 0L, "999999");
+      assert false;
+    } catch (Exception e) {
+      assert e instanceof IllegalArgumentException;
+    }
     TransactionExtention transactionExtention = client.triggerConstantContract(fromAddr, usdtAddr,
         encodedHex, 0L, 0L, null);
     long energy = transactionExtention.getEnergyUsed();

--- a/trident-java/core/src/test/java/org/tron/trident/core/ContractTest.java
+++ b/trident-java/core/src/test/java/org/tron/trident/core/ContractTest.java
@@ -172,8 +172,9 @@ class ContractTest extends BaseTest {
             new Uint256(BigInteger.valueOf(10).multiply(BigInteger.valueOf(10).pow(6)))),
         Collections.singletonList(new TypeReference<Bool>() {
         }));
+    String encodedHex = FunctionEncoder.encode(trc20Transfer);
     TransactionExtention transactionExtention = client.triggerContract(fromAddr, usdtAddr,
-        trc20Transfer);
+        encodedHex, 0, 0, null, Constant.FEE_LIMIT);
 
     Transaction signedTxn = client.signTransaction(transactionExtention);
 

--- a/trident-java/core/src/test/java/org/tron/trident/core/ContractTest.java
+++ b/trident-java/core/src/test/java/org/tron/trident/core/ContractTest.java
@@ -49,7 +49,8 @@ class ContractTest extends BaseTest {
 
   @Test
   void testTransfer() throws InterruptedException, IllegalException {
-    TransactionExtention transactionExtention = client.transfer(testAddress, "TAB1TVw5N8g1FLcKxPD17h2A3eEpSXvMQd", 1_000_000L);
+    TransactionExtention transactionExtention = client.transfer(testAddress,
+        "TAB1TVw5N8g1FLcKxPD17h2A3eEpSXvMQd", 1_000_000L);
     Transaction transaction = client.signTransaction(transactionExtention);
     String txId = client.broadcastTransaction(transaction);
 
@@ -69,7 +70,8 @@ class ContractTest extends BaseTest {
             + "810290910101528051600390829060029081106100de57fe5b6020908102909101015280518190849081106100f657fe5b906020019060200201519150509190505600a16562"
             + "7a7a72305820b24fc247fdaf3644b3c4c94fcee380aa610ed83415061ff9e65d7fa94a5a50a00029";
 
-    TransactionExtention transactionExtention = client.deployContract("testDeployContract", abiStr, bytecode);
+    TransactionExtention transactionExtention = client.deployContract("testDeployContract", abiStr,
+        bytecode);
 
     Transaction transaction = client.signTransaction(transactionExtention.getTransaction());
     String txId = client.broadcastTransaction(transaction);
@@ -92,7 +94,8 @@ class ContractTest extends BaseTest {
         new Uint256(BigInteger.valueOf(100))  // initTotal 100
     );
 
-    TransactionExtention transactionExtention = client.deployContract("testDConstructorParams", abiStr, bytecode,
+    TransactionExtention transactionExtention = client.deployContract("testDConstructorParams",
+        abiStr, bytecode,
         constructorParams, 1000_000_000L, 100,
         10_000_000L, 0L, null, 0L);
     //System.out.println("Transaction ID: " + txId);
@@ -120,7 +123,8 @@ class ContractTest extends BaseTest {
     );
 
     //callValue 1TRX
-    TransactionExtention transactionExtention = client.deployContract("testDConstructorParams", abiStr, bytecode,
+    TransactionExtention transactionExtention = client.deployContract("testDConstructorParams",
+        abiStr, bytecode,
         constructorParams, 100_000_000L, 100,
         10_000_000L, 1_000_000L, null, 0L);
 
@@ -142,7 +146,8 @@ class ContractTest extends BaseTest {
     //callValue 1TRX
     //tokenId
     //tokenValue 10
-    TransactionExtention transactionExtention = client.deployContract("testDeployContractWithTRC10", abiStr, bytecode,
+    TransactionExtention transactionExtention = client.deployContract("testDeployContractWithTRC10",
+        abiStr, bytecode,
         null, 100_000_000L, 100,
         10_000_000L, 1_000_000L, tokenId, 10L);
     //System.out.println("Transaction ID: " + txId);
@@ -179,6 +184,27 @@ class ContractTest extends BaseTest {
     TransactionInfo transactionInfo = client.getTransactionInfoById(ret);
     assertEquals(0, transactionInfo.getResult().getNumber());
 
+  }
+
+  @Test
+  void testTriggerContractWithFeeLimit() {
+    // transfer(address,uint256) returns (bool)
+    String usdtAddr = "TXYZopYRdj2D9XRtbG411XZZ3kM5VkAeBf"; //nile
+    String fromAddr = client.keyPair.toBase58CheckAddress();
+    String toAddress = "TVjsyZ7fYF3qLF6BQgPmTEZy1xrNNyVAAA";
+    Function trc20Transfer = new Function("transfer",
+        Arrays.asList(new Address(toAddress),
+            new Uint256(BigInteger.valueOf(10).multiply(BigInteger.valueOf(10).pow(6)))),
+        Collections.singletonList(new TypeReference<Bool>() {
+        }));
+    String encodedHex = FunctionEncoder.encode(trc20Transfer);
+    try {
+      client.triggerContract(fromAddr, usdtAddr,
+          encodedHex, 0L, 0L, null, 0L);
+      assert false;
+    } catch (Exception e) {
+      assertTrue(e instanceof IllegalException);
+    }
   }
 
   @Test
@@ -289,8 +315,8 @@ class ContractTest extends BaseTest {
         Collections.singletonList(new TypeReference<Bool>() {
         }));
     String encodedHex = FunctionEncoder.encode(trc20Transfer);
-    TransactionExtention transactionExtention = client.triggerConstantContract(fromAddr, usdtAddr, encodedHex,
-        0L, 0L, null);
+    TransactionExtention transactionExtention = client.triggerConstantContract(fromAddr, usdtAddr,
+        encodedHex, 0L, 0L, null);
     long energy = transactionExtention.getEnergyUsed();
     assertTrue(energy > 0);
   }

--- a/trident-java/core/src/test/java/org/tron/trident/core/ContractTest.java
+++ b/trident-java/core/src/test/java/org/tron/trident/core/ContractTest.java
@@ -71,7 +71,7 @@ class ContractTest extends BaseTest {
             + "7a7a72305820b24fc247fdaf3644b3c4c94fcee380aa610ed83415061ff9e65d7fa94a5a50a00029";
 
     TransactionExtention transactionExtention = client.deployContract("testDeployContract", abiStr,
-        bytecode);
+        bytecode, null, Constant.FEE_LIMIT, 0, 1_000_000L, 0, null , 0);
 
     Transaction transaction = client.signTransaction(transactionExtention.getTransaction());
     String txId = client.broadcastTransaction(transaction);


### PR DESCRIPTION
**What does this PR do?**

- Keep only one function `triggerContract` with feeLimit
- delete funciton `deployContract` with default parameter
- add method `validateCallValue`, `validateTokenValue`

**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**