### PR TITLE
feat(api): set refer hash and expire timestamp manually when create transaction

### DIFF
--- a/trident-java/core/src/main/java/org/tron/trident/core/ApiWrapper.java
+++ b/trident-java/core/src/main/java/org/tron/trident/core/ApiWrapper.java
@@ -151,10 +151,10 @@ public class ApiWrapper implements Api {
    */
   @Getter
   @Setter
-  boolean createTransactionLocal = false;
+  boolean enableLocalCreateTransaction = false;
   /**
    * Used to set refer block number and hash when {@link #createTransaction} only if
-   * {@link #createTransactionLocal} = true. If false, use the highest solidity BlockId instead.
+   * {@link #enableLocalCreateTransaction} = true. If false, use the highest solidity BlockId instead.
    * Use {@link #resetRefer()} to reset.
    */
   @Getter
@@ -162,7 +162,7 @@ public class ApiWrapper implements Api {
   private BlockId referHeadBlockId;
   /**
    * Used to set transaction's expiration timestamp (milliseconds) when {@link #createTransaction} only if
-   * {@link #createTransactionLocal} = true. If false, use the timestamp of latest head BlockId +
+   * {@link #enableLocalCreateTransaction} = true. If false, use the timestamp of latest head BlockId +
    * TRANSACTION_DEFAULT_EXPIRATION_TIME instead. Use {@link #resetExpireTimeStamp()} to reset.
    */
   @Getter
@@ -472,7 +472,7 @@ public class ApiWrapper implements Api {
       Message message, Transaction.Contract.ContractType contractType) throws Exception {
     BlockId solidHeadBlockId;
     long transactionExpireTimeStamp;
-    if (createTransactionLocal) {
+    if (enableLocalCreateTransaction) {
       if (referHeadBlockId == null) {
         throw new NullPointerException("referHeadBlockId must not be null");
       }

--- a/trident-java/core/src/main/java/org/tron/trident/core/ApiWrapper.java
+++ b/trident-java/core/src/main/java/org/tron/trident/core/ApiWrapper.java
@@ -288,16 +288,16 @@ public class ApiWrapper implements Api {
     return new ApiWrapper(Constant.FULLNODE_NILE, Constant.FULLNODE_NILE_SOLIDITY, hexPrivateKey);
   }
 
-  public void enableLocalCreate(BlockId blockId, long expireTime) {
+  public synchronized void enableLocalCreate(BlockId blockId, long expireTime) {
     this.enableLocalCreateTx = true;
     this.referHeadBlockId = blockId;
     this.expireTimeStamp = expireTime;
   }
 
-  public void disableLocalCreate() {
+  public synchronized void disableLocalCreate() {
     this.enableLocalCreateTx = false;
-    referHeadBlockId = null;
-    expireTimeStamp = -1;
+    this.referHeadBlockId = null;
+    this.expireTimeStamp = -1;
   }
 
   public synchronized void setReferHeadBlockId(BlockId blockId) {

--- a/trident-java/core/src/main/java/org/tron/trident/core/ApiWrapper.java
+++ b/trident-java/core/src/main/java/org/tron/trident/core/ApiWrapper.java
@@ -143,7 +143,7 @@ public class ApiWrapper implements Api {
   public final ManagedChannel channelSolidity;
 
   /**
-   * Specify whether to createTransaction locally (default false) without grpc request. If true, we
+   * Specify whether to createTransaction locally (default false) without grpc request. If false, we
    * need to query referHeadBlockId and head block time through grpc api in method
    * {@link #createTransaction}. {@link #referHeadBlockId} and {@link #expireTimeStamp} must be
    * valid when it is true.

--- a/trident-java/core/src/main/java/org/tron/trident/core/ApiWrapper.java
+++ b/trident-java/core/src/main/java/org/tron/trident/core/ApiWrapper.java
@@ -461,18 +461,15 @@ public class ApiWrapper implements Api {
   private TransactionCapsule createTransaction(
       Message message, Transaction.Contract.ContractType contractType) throws Exception {
     BlockReq blockReq = BlockReq.newBuilder().setDetail(false).build();
-    BlockId solidHeadBlockId;
-    long headBlockTimeStamp;
-
+    BlockId solidHeadBlockId = referHeadBlockId;
+    long headBlockTimeStamp = referBlockTimeStamp;
     if (referHeadBlockId == null || referBlockTimeStamp <= 0) {
       BlockExtention solidHeadBlock = blockingStubSolidity.getBlock(blockReq);
       BlockExtention headBlock = blockingStub.getBlock(blockReq);
       solidHeadBlockId = Utils.getBlockId(solidHeadBlock);
       headBlockTimeStamp = headBlock.getBlockHeader().getRawData().getTimestamp();
-    } else {
-      solidHeadBlockId = referHeadBlockId;
-      headBlockTimeStamp = referBlockTimeStamp;
     }
+
     return createTransactionCapsuleWithoutValidate(message, contractType,
         solidHeadBlockId, headBlockTimeStamp);
   }

--- a/trident-java/core/src/main/java/org/tron/trident/core/ApiWrapper.java
+++ b/trident-java/core/src/main/java/org/tron/trident/core/ApiWrapper.java
@@ -463,10 +463,12 @@ public class ApiWrapper implements Api {
     BlockReq blockReq = BlockReq.newBuilder().setDetail(false).build();
     BlockId solidHeadBlockId = referHeadBlockId;
     long headBlockTimeStamp = referBlockTimeStamp;
-    if (referHeadBlockId == null || referBlockTimeStamp <= 0) {
+    if (solidHeadBlockId == null) {
       BlockExtention solidHeadBlock = blockingStubSolidity.getBlock(blockReq);
-      BlockExtention headBlock = blockingStub.getBlock(blockReq);
       solidHeadBlockId = Utils.getBlockId(solidHeadBlock);
+    }
+    if (headBlockTimeStamp <= 0) {
+      BlockExtention headBlock = blockingStub.getBlock(blockReq);
       headBlockTimeStamp = headBlock.getBlockHeader().getRawData().getTimestamp();
     }
 

--- a/trident-java/core/src/main/java/org/tron/trident/core/transaction/BlockId.java
+++ b/trident-java/core/src/main/java/org/tron/trident/core/transaction/BlockId.java
@@ -1,5 +1,7 @@
 package org.tron.trident.core.transaction;
 
+import com.google.common.primitives.Longs;
+import com.google.protobuf.ByteString;
 import java.util.Arrays;
 import org.tron.trident.core.utils.Sha256Hash;
 
@@ -7,11 +9,33 @@ public class BlockId extends Sha256Hash {
 
   private long num;
 
+  public BlockId() {
+    super(Sha256Hash.ZERO_HASH.getBytes());
+    num = 0;
+  }
+
+  public BlockId(Sha256Hash blockId) {
+    super(blockId.getBytes());
+    byte[] blockNum = new byte[8];
+    System.arraycopy(blockId.getBytes(), 0, blockNum, 0, 8);
+    num = Longs.fromByteArray(blockNum);
+  }
+
   /**
    * Use {@link #wrap(byte[])} instead.
    */
   public BlockId(Sha256Hash hash, long num) {
     super(num, hash);
+    this.num = num;
+  }
+
+  public BlockId(byte[] hash, long num) {
+    super(num, hash);
+    this.num = num;
+  }
+
+  public BlockId(ByteString hash, long num) {
+    super(num, hash.toByteArray());
     this.num = num;
   }
 

--- a/trident-java/core/src/test/java/org/tron/trident/core/ContractTest.java
+++ b/trident-java/core/src/test/java/org/tron/trident/core/ContractTest.java
@@ -347,7 +347,7 @@ class ContractTest extends BaseTest {
     long refBlockNum = new Random().nextInt(100);
     byte[] refBlockNumBytes = ByteArray.fromLong(refBlockNum);
     long timestamp = System.currentTimeMillis();
-    client.setCreateTransactionLocal(true);
+    client.setEnableLocalCreateTransaction(true);
 
     try {
       client.transferTrc10(testAddress,
@@ -367,7 +367,7 @@ class ContractTest extends BaseTest {
         transactionExtention.getTransaction().getRawData().getRefBlockBytes().toByteArray());
     assertEquals(timestamp, transactionExtention.getTransaction().getRawData().getExpiration());
 
-    client.setCreateTransactionLocal(false);
+    client.setEnableLocalCreateTransaction(false);
     transactionExtention = client.transferTrc10(testAddress,
         "TAB1TVw5N8g1FLcKxPD17h2A3eEpSXvMQd", Integer.parseInt(tokenId), 100);
 

--- a/trident-java/core/src/test/java/org/tron/trident/core/ContractTest.java
+++ b/trident-java/core/src/test/java/org/tron/trident/core/ContractTest.java
@@ -2,14 +2,18 @@ package org.tron.trident.core;
 
 
 import static java.lang.Thread.sleep;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.tron.trident.core.Constant.TRANSACTION_DEFAULT_EXPIRATION_TIME;
 
 import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Random;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.tron.trident.abi.FunctionEncoder;
@@ -22,8 +26,10 @@ import org.tron.trident.abi.datatypes.Type;
 import org.tron.trident.abi.datatypes.generated.Uint256;
 import org.tron.trident.core.contract.Contract;
 import org.tron.trident.core.exceptions.IllegalException;
+import org.tron.trident.core.transaction.BlockId;
 import org.tron.trident.core.transaction.TransactionBuilder;
 import org.tron.trident.core.utils.ByteArray;
+import org.tron.trident.core.utils.Sha256Hash;
 import org.tron.trident.proto.Chain.Transaction;
 import org.tron.trident.proto.Response.EstimateEnergyMessage;
 import org.tron.trident.proto.Response.TransactionExtention;
@@ -336,4 +342,44 @@ class ContractTest extends BaseTest {
     assertTrue(energy > 0);
   }
 
+  @Test
+  void testRefer() throws IllegalException {
+    byte[] rawHashBytes = getBlockId();
+    long refBlockNum = new Random().nextInt(100);
+    byte[] refBlockNumBytes = ByteArray.fromLong(refBlockNum);
+    long timestamp = System.currentTimeMillis();
+    client.setReferHeadBlockId(new BlockId(Sha256Hash.wrap(rawHashBytes), refBlockNum));
+    client.setReferBlockTimeStamp(timestamp); //ms
+    TransactionExtention transactionExtention = client.transferTrc10(testAddress,
+        "TAB1TVw5N8g1FLcKxPD17h2A3eEpSXvMQd", Integer.parseInt(tokenId), 100);
+
+    assertArrayEquals(ByteArray.subArray(rawHashBytes, 8, 16),
+        transactionExtention.getTransaction().getRawData().getRefBlockHash().toByteArray());
+    assertArrayEquals(ByteArray.subArray(refBlockNumBytes, 6, 8),
+        transactionExtention.getTransaction().getRawData().getRefBlockBytes().toByteArray());
+    assertEquals(timestamp + TRANSACTION_DEFAULT_EXPIRATION_TIME,
+        transactionExtention.getTransaction().getRawData().getExpiration());
+    client.clearRefer();
+
+    transactionExtention = client.transferTrc10(testAddress,
+        "TAB1TVw5N8g1FLcKxPD17h2A3eEpSXvMQd", Integer.parseInt(tokenId), 100);
+
+    assertNotEquals(
+        ByteArray.toHexString(ByteArray.subArray(rawHashBytes, 8, 16)),
+        ByteArray.toHexString(
+            transactionExtention.getTransaction().getRawData().getRefBlockHash().toByteArray()));
+
+    assertNotEquals(ByteArray.toHexString(ByteArray.subArray(refBlockNumBytes, 6, 8)),
+        ByteArray.toHexString(
+            transactionExtention.getTransaction().getRawData().getRefBlockBytes().toByteArray()));
+
+    assertNotEquals(timestamp + TRANSACTION_DEFAULT_EXPIRATION_TIME,
+        transactionExtention.getTransaction().getRawData().getExpiration());
+  }
+
+  private byte[] getBlockId() {
+    byte[] id = new byte[32];
+    new Random().nextBytes(id);
+    return id;
+  }
 }


### PR DESCRIPTION
**What does this PR do?**

- user can set refer block hash and expire timestamp manualy when create transaction, and don't need to get latest blockId from node through grpc.
- add several construct method of BlockId

**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**