### PR TITLE
hotfix(api): fix the bug of setting timeout in ApiWrapper

### DIFF
--- a/trident-java/core/src/main/java/org/tron/trident/core/ApiWrapper.java
+++ b/trident-java/core/src/main/java/org/tron/trident/core/ApiWrapper.java
@@ -1,6 +1,5 @@
 package org.tron.trident.core;
 
-import static org.tron.trident.core.Constant.GRPC_TIMEOUT;
 import static org.tron.trident.core.Constant.TRANSACTION_DEFAULT_EXPIRATION_TIME;
 import static org.tron.trident.core.utils.TokenValidator.validateCallValue;
 import static org.tron.trident.core.utils.TokenValidator.validateTokenId;
@@ -167,10 +166,8 @@ public class ApiWrapper implements Api {
   public ApiWrapper(String grpcEndpoint, String grpcEndpointSolidity, String hexPrivateKey) {
     channel = ManagedChannelBuilder.forTarget(grpcEndpoint).usePlaintext().build();
     channelSolidity = ManagedChannelBuilder.forTarget(grpcEndpointSolidity).usePlaintext().build();
-    blockingStub = WalletGrpc.newBlockingStub(channel)
-        .withDeadlineAfter(GRPC_TIMEOUT, TimeUnit.MILLISECONDS);
-    blockingStubSolidity = WalletSolidityGrpc.newBlockingStub(channelSolidity)
-        .withDeadlineAfter(GRPC_TIMEOUT, TimeUnit.MILLISECONDS);
+    blockingStub = WalletGrpc.newBlockingStub(channel);
+    blockingStubSolidity = WalletSolidityGrpc.newBlockingStub(channelSolidity);
     keyPair = new KeyPair(hexPrivateKey);
   }
 
@@ -187,11 +184,9 @@ public class ApiWrapper implements Api {
 
     //create a client to interceptor to attach the custom metadata headers
     blockingStub = WalletGrpc.newBlockingStub(channel)
-        .withInterceptors(MetadataUtils.newAttachHeadersInterceptor(header))
-        .withDeadlineAfter(GRPC_TIMEOUT, TimeUnit.MILLISECONDS);
+        .withInterceptors(MetadataUtils.newAttachHeadersInterceptor(header));
     blockingStubSolidity = WalletSolidityGrpc.newBlockingStub(channelSolidity)
-        .withInterceptors(MetadataUtils.newAttachHeadersInterceptor(header))
-        .withDeadlineAfter(GRPC_TIMEOUT, TimeUnit.MILLISECONDS);
+        .withInterceptors(MetadataUtils.newAttachHeadersInterceptor(header));
 
     keyPair = new KeyPair(hexPrivateKey);
   }
@@ -203,10 +198,8 @@ public class ApiWrapper implements Api {
         .usePlaintext()
         .build();
     channelSolidity = ManagedChannelBuilder.forTarget(grpcEndpointSolidity).usePlaintext().build();
-    blockingStub = WalletGrpc.newBlockingStub(channel)
-        .withDeadlineAfter(GRPC_TIMEOUT, TimeUnit.MILLISECONDS);
-    blockingStubSolidity = WalletSolidityGrpc.newBlockingStub(channelSolidity)
-        .withDeadlineAfter(GRPC_TIMEOUT, TimeUnit.MILLISECONDS);
+    blockingStub = WalletGrpc.newBlockingStub(channel);
+    blockingStubSolidity = WalletSolidityGrpc.newBlockingStub(channelSolidity);
     keyPair = new KeyPair(hexPrivateKey);
   }
 

--- a/trident-java/core/src/main/java/org/tron/trident/core/ApiWrapper.java
+++ b/trident-java/core/src/main/java/org/tron/trident/core/ApiWrapper.java
@@ -208,12 +208,12 @@ public class ApiWrapper implements Api {
    */
   public ApiWrapper(String grpcEndpoint, String grpcEndpointSolidity, String hexPrivateKey,
       int timeout) {
-    channel = ManagedChannelBuilder.forTarget(grpcEndpoint).usePlaintext().build();
+    channel = ManagedChannelBuilder.forTarget(grpcEndpoint)
+        .idleTimeout(timeout, TimeUnit.MILLISECONDS)
+        .usePlaintext().build();
     channelSolidity = ManagedChannelBuilder.forTarget(grpcEndpointSolidity).usePlaintext().build();
-    blockingStub = WalletGrpc.newBlockingStub(channel)
-        .withDeadlineAfter(timeout, TimeUnit.MILLISECONDS);
-    blockingStubSolidity = WalletSolidityGrpc.newBlockingStub(channelSolidity)
-        .withDeadlineAfter(timeout, TimeUnit.MILLISECONDS);
+    blockingStub = WalletGrpc.newBlockingStub(channel);
+    blockingStubSolidity = WalletSolidityGrpc.newBlockingStub(channelSolidity);
     keyPair = new KeyPair(hexPrivateKey);
   }
 
@@ -224,13 +224,12 @@ public class ApiWrapper implements Api {
       List<ClientInterceptor> clientInterceptors, int timeout) {
     channel = ManagedChannelBuilder.forTarget(grpcEndpoint)
         .intercept(clientInterceptors)
+        .idleTimeout(timeout, TimeUnit.MILLISECONDS)
         .usePlaintext()
         .build();
     channelSolidity = ManagedChannelBuilder.forTarget(grpcEndpointSolidity).usePlaintext().build();
-    blockingStub = WalletGrpc.newBlockingStub(channel)
-        .withDeadlineAfter(timeout, TimeUnit.MILLISECONDS);
-    blockingStubSolidity = WalletSolidityGrpc.newBlockingStub(channelSolidity)
-        .withDeadlineAfter(timeout, TimeUnit.MILLISECONDS);
+    blockingStub = WalletGrpc.newBlockingStub(channel);
+    blockingStubSolidity = WalletSolidityGrpc.newBlockingStub(channelSolidity);
     keyPair = new KeyPair(hexPrivateKey);
   }
 

--- a/trident-java/core/src/main/java/org/tron/trident/core/Constant.java
+++ b/trident-java/core/src/main/java/org/tron/trident/core/Constant.java
@@ -15,7 +15,7 @@ public final class Constant {
 
   public static final long TRANSACTION_DEFAULT_EXPIRATION_TIME = 60 * 1_000L; //60 seconds
 
-  public static final long GRPC_TIMEOUT = 30 * 1_000L; //30 seconds
+  //public static final long GRPC_TIMEOUT = 30 * 1_000L; //30 seconds
 
   public static final String TRX_SYMBOL = "_";
 

--- a/trident-java/core/src/test/java/org/tron/trident/core/ApiWrapperTest.java
+++ b/trident-java/core/src/test/java/org/tron/trident/core/ApiWrapperTest.java
@@ -1,5 +1,6 @@
 package org.tron.trident.core;
 
+import static java.lang.Thread.sleep;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -16,7 +17,6 @@ import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import org.bouncycastle.util.encoders.Hex;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.tron.trident.abi.FunctionEncoder;
@@ -57,15 +57,23 @@ class ApiWrapperTest extends BaseTest {
   }
 
   @Test
-  void testGetNowBlockQueryWithTimeout() throws IllegalException {
+  void testGetNowBlockQueryWithTimeout() throws IllegalException, InterruptedException {
     List<ClientInterceptor> clientInterceptors = new ArrayList<>();
+    int timeout = 2000;
     ApiWrapper client = new ApiWrapper(Constant.FULLNODE_NILE, Constant.FULLNODE_NILE_SOLIDITY,
         KeyPair.generate().toPrivateKey(), clientInterceptors,
-        2000);
+        timeout);
     Chain.Block block = client.getNowBlock();
 
     //System.out.println(block.getBlockHeader());
     assertTrue(block.getBlockHeader().getRawDataOrBuilder().getNumber() > 0);
+
+    sleep(timeout + 10000);
+    try {
+      client.getNowBlock();
+    } catch (io.grpc.StatusRuntimeException e) {
+      assert false;
+    }
   }
 
   @Test

--- a/trident-java/core/src/test/java/org/tron/trident/core/ApiWrapperTest.java
+++ b/trident-java/core/src/test/java/org/tron/trident/core/ApiWrapperTest.java
@@ -59,7 +59,7 @@ class ApiWrapperTest extends BaseTest {
   @Test
   void testGetNowBlockQueryWithTimeout() throws IllegalException, InterruptedException {
     List<ClientInterceptor> clientInterceptors = new ArrayList<>();
-    int timeout = 2000;
+    int timeout = 4000;
     ApiWrapper client = new ApiWrapper(Constant.FULLNODE_NILE, Constant.FULLNODE_NILE_SOLIDITY,
         KeyPair.generate().toPrivateKey(), clientInterceptors,
         timeout);
@@ -68,9 +68,26 @@ class ApiWrapperTest extends BaseTest {
     //System.out.println(block.getBlockHeader());
     assertTrue(block.getBlockHeader().getRawDataOrBuilder().getNumber() > 0);
 
-    sleep(timeout + 10000);
+    sleep(timeout + timeout);
     try {
       client.getNowBlock();
+    } catch (io.grpc.StatusRuntimeException e) {
+      assert false;
+    }
+  }
+
+  @Test
+  void testBlockingStubWithTimeout() throws IllegalException, InterruptedException {
+    List<ClientInterceptor> clientInterceptors = new ArrayList<>();
+    int timeout = 4000;
+    ApiWrapper client = new ApiWrapper(Constant.FULLNODE_NILE, Constant.FULLNODE_NILE_SOLIDITY,
+        KeyPair.generate().toPrivateKey(), clientInterceptors,
+        timeout);
+    client.blockingStub.getNowBlock(EmptyMessage.newBuilder().build());
+
+    sleep(timeout + timeout);
+    try {
+      client.blockingStub.getNowBlock(EmptyMessage.newBuilder().build());
     } catch (io.grpc.StatusRuntimeException e) {
       assert false;
     }

--- a/trident-java/core/src/test/java/org/tron/trident/core/ExchangeTest.java
+++ b/trident-java/core/src/test/java/org/tron/trident/core/ExchangeTest.java
@@ -88,7 +88,7 @@ public class ExchangeTest extends BaseTest {
   void testExchangeTransaction() throws IllegalException, InterruptedException {
     //expected should be smaller than left value in that exchange.
     TransactionExtention transactionExtention = client.exchangeTransaction(testAddress, exchangeID,
-        "_", 20_000_000L, 10_000_000L);
+        "_", 20_000_000L, 4_000_000L);
 
     Transaction transaction = client.signTransaction(transactionExtention);
     String txId = client.broadcastTransaction(transaction);


### PR DESCRIPTION
**What does this PR do?**

- remove default timeout in constructor of ApiWrapper if timeout is not included in parameters

**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**