### PR TITLE
Added support for SSL-enabled GRPC endpoints.

### DIFF
--- a/core/src/main/java/org/tron/trident/core/ApiWrapper.java
+++ b/core/src/main/java/org/tron/trident/core/ApiWrapper.java
@@ -174,8 +174,8 @@ public class ApiWrapper implements Api {
   private long expireTimeStamp = -1;
 
   public ApiWrapper(String grpcEndpoint, String grpcEndpointSolidity, String hexPrivateKey) {
-    channel = ManagedChannelBuilder.forTarget(grpcEndpoint).usePlaintext().build();
-    channelSolidity = ManagedChannelBuilder.forTarget(grpcEndpointSolidity).usePlaintext().build();
+    channel = channelFor(grpcEndpoint).build();
+    channelSolidity = channelFor(grpcEndpointSolidity).build();
     blockingStub = WalletGrpc.newBlockingStub(channel);
     blockingStubSolidity = WalletSolidityGrpc.newBlockingStub(channelSolidity);
     keyPair = new KeyPair(hexPrivateKey);
@@ -183,8 +183,8 @@ public class ApiWrapper implements Api {
 
   public ApiWrapper(String grpcEndpoint, String grpcEndpointSolidity, String hexPrivateKey,
       String apiKey) {
-    channel = ManagedChannelBuilder.forTarget(grpcEndpoint).usePlaintext().build();
-    channelSolidity = ManagedChannelBuilder.forTarget(grpcEndpointSolidity).usePlaintext().build();
+    channel = channelFor(grpcEndpoint).build();
+    channelSolidity = channelFor(grpcEndpointSolidity).build();
 
     //attach api key
     Metadata header = new Metadata();
@@ -203,11 +203,12 @@ public class ApiWrapper implements Api {
 
   public ApiWrapper(String grpcEndpoint, String grpcEndpointSolidity, String hexPrivateKey,
       List<ClientInterceptor> clientInterceptors) {
-    channel = ManagedChannelBuilder.forTarget(grpcEndpoint)
+    channel = channelFor(grpcEndpoint)
         .intercept(clientInterceptors)
-        .usePlaintext()
         .build();
-    channelSolidity = ManagedChannelBuilder.forTarget(grpcEndpointSolidity).usePlaintext().build();
+    channelSolidity = channelFor(grpcEndpointSolidity)
+        .intercept(clientInterceptors)
+        .build();
     blockingStub = WalletGrpc.newBlockingStub(channel);
     blockingStubSolidity = WalletSolidityGrpc.newBlockingStub(channelSolidity);
     keyPair = new KeyPair(hexPrivateKey);
@@ -218,14 +219,10 @@ public class ApiWrapper implements Api {
    */
   public ApiWrapper(String grpcEndpoint, String grpcEndpointSolidity, String hexPrivateKey,
       int timeout) {
-    channel = ManagedChannelBuilder
-        .forTarget(grpcEndpoint)
-        .usePlaintext()
+    channel = channelFor(grpcEndpoint)
         .intercept(new TimeoutInterceptor(timeout))
         .build();
-    channelSolidity = ManagedChannelBuilder
-        .forTarget(grpcEndpointSolidity)
-        .usePlaintext()
+    channelSolidity = channelFor(grpcEndpointSolidity)
         .intercept(new TimeoutInterceptor(timeout))
         .build();
     blockingStub = WalletGrpc.newBlockingStub(channel);
@@ -252,13 +249,11 @@ public class ApiWrapper implements Api {
     }
 
     channel =
-        ManagedChannelBuilder.forTarget(grpcEndpoint)
-            .usePlaintext()
+        channelFor(grpcEndpoint)
             .intercept(clientInterceptorList)
             .build();
     channelSolidity =
-        ManagedChannelBuilder.forTarget(grpcEndpointSolidity)
-            .usePlaintext()
+        channelFor(grpcEndpointSolidity)
             .intercept(clientInterceptorList)
             .build();
     blockingStub = WalletGrpc.newBlockingStub(channel);
@@ -266,7 +261,24 @@ public class ApiWrapper implements Api {
     keyPair = new KeyPair(hexPrivateKey);
   }
 
-  /**
+    /**
+     * construct channel builder from endpoint
+     * @param endpoint
+     * @return
+     */
+  private static ManagedChannelBuilder<?> channelFor(String endpoint){
+      if (endpoint == null) {
+          throw new IllegalArgumentException("Endpoint cannot be null");
+      }
+      if(endpoint.startsWith("https://")){
+          return ManagedChannelBuilder.forTarget(endpoint.substring(8)).useTransportSecurity();
+      } else {
+          return ManagedChannelBuilder.forTarget(endpoint).usePlaintext();
+      }
+  }
+
+
+    /**
    * The constructor for main net. Use TronGrid as default
    *
    * @param hexPrivateKey the binding private key. Operations require private key will all use this unless the private key is specified elsewhere.

--- a/core/src/main/java/org/tron/trident/core/ApiWrapper.java
+++ b/core/src/main/java/org/tron/trident/core/ApiWrapper.java
@@ -266,7 +266,7 @@ public class ApiWrapper implements Api {
      * @param endpoint
      * @return
      */
-  private static ManagedChannelBuilder<?> channelFor(String endpoint){
+  protected ManagedChannelBuilder<?> channelFor(String endpoint){
       if (endpoint == null) {
           throw new IllegalArgumentException("Endpoint cannot be null");
       }


### PR DESCRIPTION
Added support for SSL enabled GRPC endpoints, keeping existing code for generic GRPC without SSL. Currently any attempt to use SSL with GRPC will fail due to usePlaintext() invoked for channel construction. 