### PR TITLE
fix(api): getAccountPermissions return null for not exist account

### DIFF
--- a/core/src/main/java/org/tron/trident/core/ApiWrapper.java
+++ b/core/src/main/java/org/tron/trident/core/ApiWrapper.java
@@ -2065,8 +2065,7 @@ public class ApiWrapper implements Api {
   /**
    * Retrieves the permissions of a TRON account.
    *
-   * <p>This is a utility method provided by Trident for multi-signature
-   * operations. It queries the account using {@link #getAccount(String, NodeType...)} and
+   * <p>It queries the account using {@link #getAccount(String, NodeType...)} and
    * wraps the result into an {@link AccountPermissions} object.
    *
    * @param address account, in any allowed formats.

--- a/core/src/main/java/org/tron/trident/core/ApiWrapper.java
+++ b/core/src/main/java/org/tron/trident/core/ApiWrapper.java
@@ -2062,6 +2062,19 @@ public class ApiWrapper implements Api {
     return accountPermissionUpdate(builder.build());
   }
 
+  /**
+   * Retrieves the permissions of a TRON account.
+   *
+   * <p>This is a utility method provided by Trident for multi-signature
+   * operations. It queries the account using {@link #getAccount(String, NodeType...)} and
+   * wraps the result into an {@link AccountPermissions} object.
+   *
+   * @param address account, in any allowed formats.
+   * @param nodeType Optional parameter to specify which node to query.
+   *                If not provided, use full node default.
+   *                If NodeType.SOLIDITY_NODE, use solidity node.
+   * @return AccountPermissions, null if the account does not exist or inactive
+   */
   public AccountPermissions getAccountPermissions(String address, NodeType... nodeType) {
     ByteString bsAddress = parseAddress(address);
     AccountAddressMessage accountAddressMessage = AccountAddressMessage.newBuilder()
@@ -2071,6 +2084,11 @@ public class ApiWrapper implements Api {
     Account account =  useSolidityNode(nodeType)
         ? blockingStubSolidity.getAccount(accountAddressMessage)
         : blockingStub.getAccount(accountAddressMessage);
+
+    // if account not exists or inactive, return null
+    if (account.getAddress().isEmpty()) {
+      return null;
+    }
 
     return new AccountPermissions(account);
   }

--- a/core/src/test/java/org/tron/trident/core/ApiWrapperTest.java
+++ b/core/src/test/java/org/tron/trident/core/ApiWrapperTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -22,6 +23,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.tron.trident.abi.datatypes.Address;
 import org.tron.trident.api.GrpcAPI.EmptyMessage;
+import org.tron.trident.core.account.AccountPermissions;
 import org.tron.trident.core.exceptions.IllegalException;
 import org.tron.trident.core.key.KeyPair;
 import org.tron.trident.core.utils.ByteArray;
@@ -315,5 +317,12 @@ class ApiWrapperTest {
     if (retryCount > maxRetries) {
       fail("getPaginatedNowWitnessList failed after " + maxRetries + " retries");
     }
+  }
+
+  @Test
+  void testGetAccountPermissions() {
+    AccountPermissions accountPermissions
+        = client.getAccountPermissions(ApiWrapper.generateAddress().toBase58CheckAddress());
+    assertNull(accountPermissions);
   }
 }


### PR DESCRIPTION
**What does this PR do?**
getAccountPermissions return null if the account does not exist

**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

