### PR TITLE
feat(core): constructor supports method chaining and support TLS

### DIFF
--- a/core/src/main/java/org/tron/trident/core/ApiWrapper.java
+++ b/core/src/main/java/org/tron/trident/core/ApiWrapper.java
@@ -448,15 +448,19 @@ public class ApiWrapper implements Api {
     }
 
     if (nodeType[0] == NodeType.SOLIDITY_NODE) {
-      if (this.channelSolidity == null
-          || this.channelSolidity.isShutdown()
-          || this.channelSolidity.isTerminated()) {
-        throw new IllegalArgumentException("the channelSolidity is null or close");
-      }
+      checkSolidityChannel();
       return true;
     }
 
     return false;
+  }
+
+  private void checkSolidityChannel() {
+    if (this.channelSolidity == null
+        || this.channelSolidity.isShutdown()
+        || this.channelSolidity.isTerminated()) {
+      throw new IllegalArgumentException("the channelSolidity is null or close");
+    }
   }
 
   public static VoteWitnessContract createVoteWitnessContract(ByteString ownerAddress,
@@ -2156,11 +2160,7 @@ public class ApiWrapper implements Api {
   @Deprecated
   @Override
   public Account getAccountSolidity(String address) {
-    if (channelSolidity == null
-        || channelSolidity.isShutdown()
-        || channelSolidity.isTerminated()) {
-      throw new IllegalArgumentException("the channelSolidity is null or close");
-    }
+    checkSolidityChannel();
     ByteString bsAddress = parseAddress(address);
     AccountAddressMessage accountAddressMessage = AccountAddressMessage.newBuilder()
         .setAddress(bsAddress)
@@ -2181,11 +2181,7 @@ public class ApiWrapper implements Api {
   @Override
   public TransactionInfoList getTransactionInfoByBlockNumSolidity(long blockNum)
       throws IllegalException {
-    if (channelSolidity == null
-        || channelSolidity.isShutdown()
-        || channelSolidity.isTerminated()) {
-      throw new IllegalArgumentException("the channelSolidity is null or close");
-    }
+    checkSolidityChannel();
     if (blockNum < 0) {
       throw new IllegalException("blockNum must be >= 0");
     }
@@ -2205,11 +2201,7 @@ public class ApiWrapper implements Api {
   @Override
   public BlockExtention getNowBlockSolidity() throws IllegalException {
 
-    if (channelSolidity == null
-        || channelSolidity.isShutdown()
-        || channelSolidity.isTerminated()) {
-      throw new IllegalArgumentException("the channelSolidity is null or close");
-    }
+    checkSolidityChannel();
     BlockExtention blockExtention = blockingStubSolidity.getNowBlock2(
         EmptyMessage.newBuilder().build());
 
@@ -2232,11 +2224,7 @@ public class ApiWrapper implements Api {
   @Override
   public Transaction getTransactionByIdSolidity(String txID) throws IllegalException {
 
-    if (channelSolidity == null
-        || channelSolidity.isShutdown()
-        || channelSolidity.isTerminated()) {
-      throw new IllegalArgumentException("the channelSolidity is null or close");
-    }
+    checkSolidityChannel();
 
     ByteString bsTxId = ByteString.copyFrom(ByteArray.fromHexString(txID));
     BytesMessage request = BytesMessage.newBuilder()

--- a/core/src/main/java/org/tron/trident/core/ApiWrapper.java
+++ b/core/src/main/java/org/tron/trident/core/ApiWrapper.java
@@ -6,19 +6,20 @@ import static org.tron.trident.core.utils.TokenValidator.validateTokenId;
 import static org.tron.trident.core.utils.TokenValidator.validateTokenValue;
 import static org.tron.trident.core.utils.Utils.encodeParameter;
 
+import com.google.common.base.Preconditions;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Message;
+import io.grpc.ChannelCredentials;
 import io.grpc.ClientInterceptor;
+import io.grpc.Grpc;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
-import io.grpc.Metadata;
-import io.grpc.stub.MetadataUtils;
-import java.util.ArrayList;
+import io.grpc.TlsChannelCredentials;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Objects;
 import lombok.Getter;
 import org.bouncycastle.jcajce.provider.digest.SHA256;
 import org.tron.trident.abi.FunctionEncoder;
@@ -45,7 +46,6 @@ import org.tron.trident.core.account.AccountPermissions;
 import org.tron.trident.core.contract.Contract;
 import org.tron.trident.core.contract.ContractFunction;
 import org.tron.trident.core.exceptions.IllegalException;
-import org.tron.trident.core.interceptor.TimeoutInterceptor;
 import org.tron.trident.core.key.KeyPair;
 import org.tron.trident.core.transaction.BlockId;
 import org.tron.trident.core.transaction.TransactionBuilder;
@@ -130,14 +130,30 @@ import org.tron.trident.proto.Response.TransactionSignWeight;
 import org.tron.trident.proto.Response.WitnessList;
 import org.tron.trident.utils.Base58Check;
 import org.tron.trident.utils.Numeric;
+import org.tron.trident.utils.Strings;
 
 /**
- * A {@code ApiWrapper} object is the entry point for calling the functions.
+ * The entry point for interacting with the TRON network.
  *
- * <p>A {@code ApiWrapper} object is bind with a private key and a full node.
- * {@link #broadcastTransaction}, {@link #signTransaction} and other transaction related
- * operations can be done via a {@code ApiWrapper} object.</p>
+ * <p>An {@code ApiWrapper} instance is bound to a full node and allows performing various
+ * operations such as {@link #broadcastTransaction}, {@link #signTransaction}, and other
+ * transaction-related actions.</p>
  *
+ * <p>It is recommended to use the Builder pattern to create an instance. For example:</p>
+ *
+ * <pre>{@code
+ * // Full-featured client with both FullNode and SolidityNode access
+ * ApiWrapper client = new ApiWrapperBuilder(grpcEndpoint, grpcEndpointSolidity, privateKey)
+ *     .withApiKey("your-api-key")       // Optional: set API key for TronGrid
+ *     .withTLS()                        // Optional: enable TLS,use withTLS(new File("xxx.crt"))
+ *     .withTimeout(5000)                // Optional: set request timeout in milliseconds
+ *     .build();
+ *
+ * // Simple client for FullNode queries only
+ * ApiWrapper client = new ApiWrapperBuilder(grpcEndpoint).build();
+ * }</pre>
+ *
+ * <p>Use {@code ApiWrapper} to interact with contracts and transactions on the TRON network.</p>
  * @see org.tron.trident.core.contract.Contract
  * @see org.tron.trident.proto.Chain.Transaction
  * @see org.tron.trident.proto.Contract
@@ -174,114 +190,110 @@ public class ApiWrapper implements Api {
   @Getter
   private long expireTimeStamp = -1;
 
-  public ApiWrapper(String grpcEndpoint, String grpcEndpointSolidity, String hexPrivateKey) {
-    channel = ManagedChannelBuilder.forTarget(grpcEndpoint)
-        .usePlaintext()
-        .build();
-    channelSolidity = ManagedChannelBuilder.forTarget(grpcEndpointSolidity)
-        .usePlaintext()
-        .build();
+  public ApiWrapper(ApiWrapperBuilder builder) {
+
+    // Build channels with interceptors and Create stubs
+    channel = buildChannel(builder, builder.getGrpcEndpoint());
     blockingStub = WalletGrpc.newBlockingStub(channel);
-    blockingStubSolidity = WalletSolidityGrpc.newBlockingStub(channelSolidity);
-    keyPair = new KeyPair(hexPrivateKey);
-  }
 
-  public ApiWrapper(String grpcEndpoint, String grpcEndpointSolidity, String hexPrivateKey,
-      String apiKey) {
-    channel = ManagedChannelBuilder.forTarget(grpcEndpoint)
-        .usePlaintext()
-        .build();
-    channelSolidity = ManagedChannelBuilder.forTarget(grpcEndpointSolidity)
-        .usePlaintext()
-        .build();
-
-    //attach api key
-    Metadata header = new Metadata();
-    Metadata.Key<String> key = Metadata.Key.of("TRON-PRO-API-KEY",
-        Metadata.ASCII_STRING_MARSHALLER);
-    header.put(key, apiKey);
-
-    //create a client to interceptor to attach the custom metadata headers
-    blockingStub = WalletGrpc.newBlockingStub(channel)
-        .withInterceptors(MetadataUtils.newAttachHeadersInterceptor(header));
-    blockingStubSolidity = WalletSolidityGrpc.newBlockingStub(channelSolidity)
-        .withInterceptors(MetadataUtils.newAttachHeadersInterceptor(header));
-
-    keyPair = new KeyPair(hexPrivateKey);
-  }
-
-  public ApiWrapper(String grpcEndpoint, String grpcEndpointSolidity, String hexPrivateKey,
-      List<ClientInterceptor> clientInterceptors) {
-    channel = ManagedChannelBuilder.forTarget(grpcEndpoint)
-        .intercept(clientInterceptors)
-        .usePlaintext()
-        .build();
-    channelSolidity = ManagedChannelBuilder.forTarget(grpcEndpointSolidity)
-        .intercept(clientInterceptors)
-        .usePlaintext()
-        .build();
-    blockingStub = WalletGrpc.newBlockingStub(channel);
-    blockingStubSolidity = WalletSolidityGrpc.newBlockingStub(channelSolidity);
-    keyPair = new KeyPair(hexPrivateKey);
-  }
-
-  /*
-     constructor enable setting timeout
-   */
-  public ApiWrapper(String grpcEndpoint, String grpcEndpointSolidity, String hexPrivateKey,
-      int timeout) {
-    channel = ManagedChannelBuilder.forTarget(grpcEndpoint)
-        .usePlaintext()
-        .intercept(new TimeoutInterceptor(timeout))
-        .build();
-    channelSolidity = ManagedChannelBuilder.forTarget(grpcEndpointSolidity)
-        .usePlaintext()
-        .intercept(new TimeoutInterceptor(timeout))
-        .build();
-    blockingStub = WalletGrpc.newBlockingStub(channel);
-    blockingStubSolidity = WalletSolidityGrpc.newBlockingStub(channelSolidity);
-    keyPair = new KeyPair(hexPrivateKey);
-  }
-
-  /*
-     constructor enable setting timeout and custom interceptors
-   */
-  public ApiWrapper(String grpcEndpoint, String grpcEndpointSolidity, String hexPrivateKey,
-      List<ClientInterceptor> clientInterceptors, int timeout) {
-
-    List<ClientInterceptor> clientInterceptorList = new ArrayList<>();
-    // first set timeout to ensure the configuration takes effect
-    clientInterceptorList.add(new TimeoutInterceptor(timeout));
-
-    if (clientInterceptors != null) {
-      clientInterceptors.stream()
-          .filter(Objects::nonNull)
-          .forEach(clientInterceptorList::add);
+    if (builder.getGrpcEndpointSolidity() != null) {
+      channelSolidity = buildChannel(builder, builder.getGrpcEndpointSolidity());
+      blockingStubSolidity = WalletSolidityGrpc.newBlockingStub(channelSolidity);
+    } else {
+      channelSolidity = null;
+      blockingStubSolidity = null;
     }
 
-    channel = ManagedChannelBuilder.forTarget(grpcEndpoint)
-        .usePlaintext()
-        .intercept(clientInterceptorList)
-        .build();
-    channelSolidity = ManagedChannelBuilder.forTarget(grpcEndpointSolidity)
-        .usePlaintext()
-        .intercept(clientInterceptorList)
-        .build();
-    blockingStub = WalletGrpc.newBlockingStub(channel);
-    blockingStubSolidity = WalletSolidityGrpc.newBlockingStub(channelSolidity);
-    keyPair = new KeyPair(hexPrivateKey);
+    keyPair = Strings.isEmpty(builder.getHexPrivateKey()) ? null : new KeyPair(
+        builder.getHexPrivateKey());
+  }
+
+  private ManagedChannel buildChannel(ApiWrapperBuilder builder, String target) {
+    ManagedChannelBuilder<?> channelBuilder;
+    if (!builder.isUseTLS()) {
+      channelBuilder =  ManagedChannelBuilder.forTarget(target).usePlaintext();
+    } else {
+      try {
+        ChannelCredentials credentials = builder.getTrustCert() == null
+            ? TlsChannelCredentials.create()
+            : TlsChannelCredentials.newBuilder().trustManager(builder.getTrustCert()).build();
+
+        channelBuilder = Grpc.newChannelBuilder(target, credentials);
+      } catch (IOException e) {
+        throw new RuntimeException("Failed to create TLS channel", e);
+      }
+    }
+
+    if (!builder.getInterceptors().isEmpty()) {
+      channelBuilder.intercept(builder.getInterceptors());
+    }
+    return channelBuilder.build();
   }
 
   /**
-   * The constructor for main net. Use TronGrid as default
+   * @deprecated Since 1.0.0, scheduled for removal in future versions. Recommend using Builder pattern to create ApiWrapper
+   * @see ApiWrapperBuilder
+   */
+  @Deprecated
+  public ApiWrapper(String grpcEndpoint, String grpcEndpointSolidity, String hexPrivateKey) {
+    this(new ApiWrapperBuilder(grpcEndpoint, grpcEndpointSolidity, hexPrivateKey));
+  }
+
+  /**
+   * @deprecated Since 1.0.0, scheduled for removal in future versions. Recommend using Builder pattern to create ApiWrapper
+   * @see ApiWrapperBuilder
+   */
+  @Deprecated
+  public ApiWrapper(
+          String grpcEndpoint, String grpcEndpointSolidity, String hexPrivateKey, String apiKey) {
+    this(new ApiWrapperBuilder(grpcEndpoint, grpcEndpointSolidity, hexPrivateKey)
+        .withApiKey(apiKey));
+  }
+
+  /**
+   * @deprecated Since 1.0.0, scheduled for removal in future versions. Recommend using Builder pattern to create ApiWrapper
+   * @see ApiWrapperBuilder
+   */
+  @Deprecated
+  public ApiWrapper(String grpcEndpoint, String grpcEndpointSolidity, String hexPrivateKey,
+                    List<ClientInterceptor> clientInterceptors) {
+    this(new ApiWrapperBuilder(grpcEndpoint, grpcEndpointSolidity, hexPrivateKey)
+            .withInterceptors(clientInterceptors));
+  }
+
+  /**
+   * @deprecated Since 1.0.0, scheduled for removal in future versions. Recommend using Builder pattern to create ApiWrapper
+   * @see ApiWrapperBuilder
+   */
+  @Deprecated
+  public ApiWrapper(String grpcEndpoint, String grpcEndpointSolidity, String hexPrivateKey,
+                    int timeout) {
+    this(new ApiWrapperBuilder(grpcEndpoint, grpcEndpointSolidity, hexPrivateKey)
+        .withTimeout(timeout));
+  }
+
+  /**
+   * @deprecated Since 1.0.0, scheduled for removal in future versions. Recommend using Builder pattern to create ApiWrapper
+   * @see ApiWrapperBuilder
+   */
+  @Deprecated
+  public ApiWrapper(String grpcEndpoint, String grpcEndpointSolidity, String hexPrivateKey,
+                    List<ClientInterceptor> clientInterceptors, int timeout) {
+    this(new ApiWrapperBuilder(grpcEndpoint, grpcEndpointSolidity, hexPrivateKey)
+            .withInterceptors(clientInterceptors)
+            .withTimeout(timeout));
+  }
+
+  /**
+   * The constructor for the main net. Use TronGrid as default
    *
    * @param hexPrivateKey the binding private key. Operations require private key will all use this unless the private key is specified elsewhere.
    * @param apiKey this function works with TronGrid, an API key is required.
    * @return a ApiWrapper object
    */
   public static ApiWrapper ofMainnet(String hexPrivateKey, String apiKey) {
-    return new ApiWrapper(Constant.TRONGRID_MAIN_NET, Constant.TRONGRID_MAIN_NET_SOLIDITY,
-        hexPrivateKey, apiKey);
+    return new ApiWrapperBuilder(Constant.TRONGRID_MAIN_NET, Constant.TRONGRID_MAIN_NET_SOLIDITY,
+        hexPrivateKey).withApiKey(apiKey).build();
   }
 
   /**
@@ -294,8 +306,8 @@ public class ApiWrapper implements Api {
    */
   @Deprecated
   public static ApiWrapper ofMainnet(String hexPrivateKey) {
-    return new ApiWrapper(Constant.TRONGRID_MAIN_NET, Constant.TRONGRID_MAIN_NET_SOLIDITY,
-        hexPrivateKey);
+    return new ApiWrapperBuilder(Constant.TRONGRID_MAIN_NET, Constant.TRONGRID_MAIN_NET_SOLIDITY,
+        hexPrivateKey).build();
   }
 
   /**
@@ -305,8 +317,8 @@ public class ApiWrapper implements Api {
    * @return a ApiWrapper object
    */
   public static ApiWrapper ofShasta(String hexPrivateKey) {
-    return new ApiWrapper(Constant.TRONGRID_SHASTA, Constant.TRONGRID_SHASTA_SOLIDITY,
-        hexPrivateKey);
+    return new ApiWrapperBuilder(Constant.TRONGRID_SHASTA, Constant.TRONGRID_SHASTA_SOLIDITY,
+        hexPrivateKey).build();
   }
 
   /**
@@ -316,7 +328,8 @@ public class ApiWrapper implements Api {
    * @return a ApiWrapper object
    */
   public static ApiWrapper ofNile(String hexPrivateKey) {
-    return new ApiWrapper(Constant.FULLNODE_NILE, Constant.FULLNODE_NILE_SOLIDITY, hexPrivateKey);
+    return new ApiWrapperBuilder(Constant.FULLNODE_NILE, Constant.FULLNODE_NILE_SOLIDITY,
+       hexPrivateKey).build();
   }
 
   /**
@@ -407,7 +420,6 @@ public class ApiWrapper implements Api {
    * @throws IllegalArgumentException if the input is null, empty, or contains invalid node type
    */
   private boolean useSolidityNode(NodeType... nodeType) {
-
     // check null
     if (nodeType == null) {
       throw new IllegalArgumentException("nodeType should not be null");
@@ -435,7 +447,16 @@ public class ApiWrapper implements Api {
       throw new IllegalArgumentException("only one nodeType is allowed");
     }
 
-    return nodeType[0] == NodeType.SOLIDITY_NODE;
+    if (nodeType[0] == NodeType.SOLIDITY_NODE) {
+      if (this.channelSolidity == null
+          || this.channelSolidity.isShutdown()
+          || this.channelSolidity.isTerminated()) {
+        throw new IllegalArgumentException("the channelSolidity is null or close");
+      }
+      return true;
+    }
+
+    return false;
   }
 
   public static VoteWitnessContract createVoteWitnessContract(ByteString ownerAddress,
@@ -504,11 +525,14 @@ public class ApiWrapper implements Api {
 
   public void close() {
     channel.shutdown();
-    channelSolidity.shutdown();
+    if (channelSolidity != null) {
+      channelSolidity.shutdown();
+    }
   }
 
   @Override
   public Transaction signTransaction(TransactionExtention txnExt, KeyPair keyPair) {
+    Preconditions.checkArgument(keyPair != null, "keyPair is null");
     byte[] txId = txnExt.getTxid().toByteArray();
     byte[] signature = KeyPair.signTransaction(txId, keyPair);
     return txnExt.getTransaction().toBuilder().addSignature(ByteString.copyFrom(signature)).build();
@@ -516,6 +540,7 @@ public class ApiWrapper implements Api {
 
   @Override
   public Transaction signTransaction(Transaction txn, KeyPair keyPair) {
+    Preconditions.checkArgument(keyPair != null, "keyPair is null");
     byte[] txId = calculateTransactionHash(txn);
     byte[] signature = KeyPair.signTransaction(txId, keyPair);
     return txn.toBuilder().addSignature(ByteString.copyFrom(signature)).build();
@@ -571,6 +596,8 @@ public class ApiWrapper implements Api {
       }
       solidHeadBlockId = referHeadBlockId;
       transactionExpireTimeStamp = expireTimeStamp;
+    } else if (blockingStubSolidity == null) {
+      throw new RuntimeException("blockingStubSolidity is null");
     } else {
       BlockReq blockReq = BlockReq.newBuilder().setDetail(false).build();
       BlockExtention solidHeadBlock = blockingStubSolidity.getBlock(blockReq);
@@ -2129,6 +2156,11 @@ public class ApiWrapper implements Api {
   @Deprecated
   @Override
   public Account getAccountSolidity(String address) {
+    if (channelSolidity == null
+        || channelSolidity.isShutdown()
+        || channelSolidity.isTerminated()) {
+      throw new IllegalArgumentException("the channelSolidity is null or close");
+    }
     ByteString bsAddress = parseAddress(address);
     AccountAddressMessage accountAddressMessage = AccountAddressMessage.newBuilder()
         .setAddress(bsAddress)
@@ -2149,6 +2181,11 @@ public class ApiWrapper implements Api {
   @Override
   public TransactionInfoList getTransactionInfoByBlockNumSolidity(long blockNum)
       throws IllegalException {
+    if (channelSolidity == null
+        || channelSolidity.isShutdown()
+        || channelSolidity.isTerminated()) {
+      throw new IllegalArgumentException("the channelSolidity is null or close");
+    }
     if (blockNum < 0) {
       throw new IllegalException("blockNum must be >= 0");
     }
@@ -2167,6 +2204,12 @@ public class ApiWrapper implements Api {
   @Deprecated
   @Override
   public BlockExtention getNowBlockSolidity() throws IllegalException {
+
+    if (channelSolidity == null
+        || channelSolidity.isShutdown()
+        || channelSolidity.isTerminated()) {
+      throw new IllegalArgumentException("the channelSolidity is null or close");
+    }
     BlockExtention blockExtention = blockingStubSolidity.getNowBlock2(
         EmptyMessage.newBuilder().build());
 
@@ -2188,6 +2231,13 @@ public class ApiWrapper implements Api {
   @Deprecated
   @Override
   public Transaction getTransactionByIdSolidity(String txID) throws IllegalException {
+
+    if (channelSolidity == null
+        || channelSolidity.isShutdown()
+        || channelSolidity.isTerminated()) {
+      throw new IllegalArgumentException("the channelSolidity is null or close");
+    }
+
     ByteString bsTxId = ByteString.copyFrom(ByteArray.fromHexString(txID));
     BytesMessage request = BytesMessage.newBuilder()
         .setValue(bsTxId)
@@ -3450,6 +3500,9 @@ public class ApiWrapper implements Api {
       ByteString newByteCode = ByteString.copyFrom(ByteArray.fromHexString(bytecode))
           .concat(constructorParamsByteString);
       bytecode = ByteArray.toHexString(newByteCode.toByteArray());
+    }
+    if (keyPair == null) {
+      throw new IllegalArgumentException("keyPair is null, should set privateKey");
     }
     CreateSmartContract createSmartContract = createSmartContract(
         contractName, keyPair.toBase58CheckAddress(), abiStr, bytecode, callValue,

--- a/core/src/main/java/org/tron/trident/core/ApiWrapperBuilder.java
+++ b/core/src/main/java/org/tron/trident/core/ApiWrapperBuilder.java
@@ -16,13 +16,13 @@ public class ApiWrapperBuilder {
   @Getter
   private final String grpcEndpoint;
   @Getter
-  private String grpcEndpointSolidity = null;
+  private String grpcEndpointSolidity;
   @Getter
-  private String hexPrivateKey = null;
+  private String hexPrivateKey;
   @Getter
-  private boolean useTLS = false;
+  private boolean useTLS;
   @Getter
-  private File trustCert = null; // Certificate for custom full node
+  private File trustCert; // Certificate for custom full node
   @Getter
   private List<ClientInterceptor> interceptors = new ArrayList<>();// Default: no timeout
 
@@ -45,10 +45,17 @@ public class ApiWrapperBuilder {
 
   /**
    * Enable TLS with custom certificate
+   * <p>
+   * Recommend using TLS 1.2 or TLS 1.3 for better security.
+   * For generating self-signed certificates, tools like OpenSSL can be used
+   * (e.g., <a href="https://docs.openssl.org/master/man1/openssl-req/">OpenSSL Req</a>).
+   * </p>
+   *
    * @param certFile The certificate file
    */
   public ApiWrapperBuilder withTLS(File certFile) {
-    Preconditions.checkArgument(certFile.exists(), "cert file does not exist");
+    Preconditions.checkNotNull(certFile, "certFile is null");
+    Preconditions.checkArgument(certFile.exists(), "cert file does not exist: " + certFile.getAbsolutePath());
     this.useTLS = true;
     this.trustCert = certFile;
     return this;
@@ -122,7 +129,7 @@ public class ApiWrapperBuilder {
         .add("grpcEndpointSolidity", grpcEndpointSolidity)
         .add("hexPrivateKey", hexPrivateKey != null ? "****" : null)
         .add("useTLS", useTLS)
-        .add("trustCert", trustCert)
+        .add("trustCert", trustCert != null ? trustCert.getAbsolutePath() : null)
         .add("interceptors", interceptors)
         .toString();
   }

--- a/core/src/main/java/org/tron/trident/core/ApiWrapperBuilder.java
+++ b/core/src/main/java/org/tron/trident/core/ApiWrapperBuilder.java
@@ -1,0 +1,130 @@
+package org.tron.trident.core;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Preconditions;
+import io.grpc.ClientInterceptor;
+import io.grpc.Metadata;
+import io.grpc.stub.MetadataUtils;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Getter;
+import org.tron.trident.core.interceptor.TimeoutInterceptor;
+import org.tron.trident.utils.Strings;
+
+public class ApiWrapperBuilder {
+  @Getter
+  private final String grpcEndpoint;
+  @Getter
+  private String grpcEndpointSolidity = null;
+  @Getter
+  private String hexPrivateKey = null;
+  @Getter
+  private boolean useTLS = false;
+  @Getter
+  private File trustCert = null; // Certificate for custom full node
+  @Getter
+  private List<ClientInterceptor> interceptors = new ArrayList<>();// Default: no timeout
+
+  public ApiWrapperBuilder(String grpcEndpoint, String grpcEndpointSolidity,
+      String hexPrivateKey) {
+    Preconditions.checkArgument(grpcEndpoint != null, "grpcEndpoint is null");
+    Preconditions.checkArgument(grpcEndpointSolidity != null, "grpcEndpointSolidity is null");
+    Preconditions.checkArgument(hexPrivateKey != null && hexPrivateKey.length() == 64,
+        "hexPrivateKey should be 64 hex characters (32 bytes)");
+
+    this.grpcEndpoint = grpcEndpoint;
+    this.grpcEndpointSolidity = grpcEndpointSolidity;
+    this.hexPrivateKey = hexPrivateKey;
+  }
+
+  public ApiWrapperBuilder(String grpcEndpoint) {
+    Preconditions.checkArgument(grpcEndpoint != null, "grpcEndpoint is null");
+    this.grpcEndpoint = grpcEndpoint;
+  }
+
+  /**
+   * Enable TLS with custom certificate
+   * @param certFile The certificate file
+   */
+  public ApiWrapperBuilder withTLS(File certFile) {
+    Preconditions.checkArgument(certFile.exists(), "cert file does not exist");
+    this.useTLS = true;
+    this.trustCert = certFile;
+    return this;
+  }
+
+  /**
+   * Enable TLS
+   */
+  public ApiWrapperBuilder withTLS() {
+    this.useTLS = true;
+    return this;
+  }
+
+  /**
+   * Set API key for TronGrid
+   */
+  public ApiWrapperBuilder withApiKey(String apiKey) {
+    Preconditions.checkArgument(!Strings.isEmpty(apiKey), "apiKey is empty");
+    Metadata header = new Metadata();
+    Metadata.Key<String> key =
+        Metadata.Key.of("TRON-PRO-API-KEY", Metadata.ASCII_STRING_MARSHALLER);
+    header.put(key, apiKey);
+    interceptors.add(MetadataUtils.newAttachHeadersInterceptor(header));
+    return this;
+  }
+
+  /**
+   * Set timeout in milliseconds for all requests
+   */
+  public ApiWrapperBuilder withTimeout(long timeoutMs) {
+    Preconditions.checkArgument(timeoutMs > 0, "timeout should be greater than 0");
+    this.interceptors.add(new TimeoutInterceptor(timeoutMs));
+    return this;
+  }
+
+  /**
+   * Add multiple custom interceptors
+   */
+  public ApiWrapperBuilder withInterceptors(List<ClientInterceptor> interceptors) {
+    Preconditions.checkArgument(interceptors != null, "interceptors is null");
+    this.interceptors.addAll(interceptors);
+    return this;
+  }
+
+  /**
+   * set grpcEndpointSolidity
+   */
+  public ApiWrapperBuilder withGrpcEndpointSolidity(String grpcEndpointSolidity) {
+    Preconditions.checkArgument(grpcEndpointSolidity != null, "grpcEndpointSolidity is null");
+    this.grpcEndpointSolidity = grpcEndpointSolidity;
+    return this;
+  }
+
+  /**
+   * set PrivateKey
+   */
+  public ApiWrapperBuilder withPrivateKey(String hexPrivateKey) {
+    Preconditions.checkArgument(hexPrivateKey != null && hexPrivateKey.length() == 64,
+        "hexPrivateKey should be 64 hex characters (32 bytes)");
+    this.hexPrivateKey = hexPrivateKey;
+    return this;
+  }
+
+  public ApiWrapper build() {
+    return new ApiWrapper(this);
+  }
+
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("grpcEndpoint", grpcEndpoint)
+        .add("grpcEndpointSolidity", grpcEndpointSolidity)
+        .add("hexPrivateKey", hexPrivateKey != null ? "****" : null)
+        .add("useTLS", useTLS)
+        .add("trustCert", trustCert)
+        .add("interceptors", interceptors)
+        .toString();
+  }
+
+}

--- a/core/src/test/java/org/tron/trident/core/ApiWrapperBuilderFunctionalTest.java
+++ b/core/src/test/java/org/tron/trident/core/ApiWrapperBuilderFunctionalTest.java
@@ -1,0 +1,220 @@
+package org.tron.trident.core;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.tron.trident.core.exceptions.IllegalException;
+import org.tron.trident.core.key.KeyPair;
+import org.tron.trident.core.utils.Utils;
+import org.tron.trident.proto.Chain.Transaction;
+import org.tron.trident.proto.Response.BlockExtention;
+import org.tron.trident.proto.Response.TransactionExtention;
+
+/**
+ * Functional tests verifying that ApiWrapper instances constructed via ApiWrapperBuilder
+ * behave correctly under different configuration scenarios.
+ */
+class ApiWrapperBuilderFunctionalTest {
+  KeyPair keyPair = KeyPair.generate();
+
+  @Test
+  void testConstructorWithThreeParameters() {
+    // Test the deprecated constructor with three parameters
+    ApiWrapper client = new ApiWrapperBuilder(Constant.FULLNODE_NILE,
+        Constant.FULLNODE_NILE_SOLIDITY, keyPair.toPrivateKey()).build();
+
+    assertNotNull(client);
+    assertNotNull(client.keyPair);
+    assertEquals(keyPair.toPrivateKey(), client.keyPair.toPrivateKey());
+    assertNotNull(client.blockingStub);
+    assertNotNull(client.blockingStubSolidity);
+
+    BlockExtention blockExtention = client.getBlock(false);
+    assertNotNull(blockExtention);
+    assertTrue(blockExtention.getTransactionsCount() >= 0);
+
+    blockExtention = client.getBlock(false, NodeType.SOLIDITY_NODE);
+    assertNotNull(blockExtention);
+    assertTrue(blockExtention.getTransactionsCount() >= 0);
+
+    client.close();
+  }
+
+  @Test
+  void testQueryWithFullNode() {
+    ApiWrapper client = new ApiWrapperBuilder(Constant.FULLNODE_NILE).build();
+
+    assertNotNull(client);
+    assertNull(client.keyPair);
+    assertNotNull(client.blockingStub);
+    assertNull(client.blockingStubSolidity);
+
+    BlockExtention blockExtention = client.getBlock(false);
+    assertNotNull(blockExtention);
+    assertTrue(blockExtention.getTransactionsCount() >= 0);
+
+    try {
+      blockExtention = client.getBlock(false, NodeType.SOLIDITY_NODE);
+      fail();
+    } catch (Exception e) {
+      assertTrue(e instanceof IllegalArgumentException);
+    }
+
+    client.close();
+  }
+
+  @Test
+  void testQueryWithFullNodeAndOtherParams() {
+    ApiWrapper client = new ApiWrapperBuilder(Constant.FULLNODE_NILE)
+        .withGrpcEndpointSolidity(Constant.FULLNODE_NILE_SOLIDITY)
+        .withTimeout(5000)
+        .build();
+
+    assertNotNull(client);
+    assertNull(client.keyPair);
+    assertNotNull(client.blockingStub);
+    assertNotNull(client.blockingStubSolidity);
+
+    BlockExtention blockExtention = client.getBlock(false);
+    assertNotNull(blockExtention);
+    assertTrue(blockExtention.getTransactionsCount() >= 0);
+
+    blockExtention = client.getBlock(false, NodeType.SOLIDITY_NODE);
+    assertNotNull(blockExtention);
+    assertTrue(blockExtention.getTransactionsCount() >= 0);
+
+    client.close();
+  }
+
+  @Test
+  void testQueryOfNile() {
+    ApiWrapper client = ApiWrapper.ofNile(keyPair.toPrivateKey());
+
+    BlockExtention blockExtention = client.getBlock(false);
+    assertNotNull(blockExtention);
+    assertTrue(blockExtention.getTransactionsCount() >= 0);
+
+    blockExtention = client.getBlock(false, NodeType.SOLIDITY_NODE);
+    assertNotNull(blockExtention);
+    assertTrue(blockExtention.getTransactionsCount() >= 0);
+
+    client.close();
+  }
+
+  @Test
+  @Disabled("server need support ssl")
+  void testTls() {
+    ApiWrapper client = new ApiWrapperBuilder("localhost:443").withTLS().build();
+
+    BlockExtention blockExtention = client.getBlock(false);
+    assertNotNull(blockExtention);
+    assertTrue(blockExtention.getTransactionsCount() >= 0);
+    client.close();
+  }
+
+  @Test
+  void testWithOutSolidityNode() {
+    String toAddress = KeyPair.generate().toBase58CheckAddress();
+    ApiWrapper client = new ApiWrapperBuilder(Constant.FULLNODE_NILE).build();
+    assertNotNull(client);
+
+    try {
+      client.getNowBlockSolidity();
+      fail();
+    } catch (Exception e) {
+      assertEquals("the channelSolidity is null or close", e.getMessage());
+    }
+
+    BlockExtention blockExtention = client.getBlock(false);
+    assertNotNull(blockExtention);
+
+    try {
+      client.transfer(keyPair.toBase58CheckAddress(), toAddress, 10);
+      fail();
+    } catch (Exception e) {
+      assertEquals("createTransactionExtention error,blockingStubSolidity is null", e.getMessage());
+    }
+
+    client.enableLocalCreate(Utils.getBlockId(blockExtention),
+        blockExtention.getBlockHeader().getRawData().getTimestamp() + 60);
+    try {
+      TransactionExtention transactionExtention
+          = client.transfer(keyPair.toBase58CheckAddress(), toAddress, 10);
+      client.signTransaction(transactionExtention, keyPair);
+    } catch (IllegalException e) {
+      throw new RuntimeException(e);
+    }
+    client.disableLocalCreate();
+    client.close();
+  }
+
+
+  @Test
+  void testWithOutPrivateKey() throws IllegalException {
+    ApiWrapper client = new ApiWrapperBuilder(Constant.FULLNODE_NILE)
+        .withGrpcEndpointSolidity(Constant.FULLNODE_NILE_SOLIDITY).build();
+    assertNotNull(client);
+    TransactionExtention transactionExtention
+        = client.transfer(keyPair.toBase58CheckAddress(),
+        KeyPair.generate().toBase58CheckAddress(), 10);
+    try {
+      client.signTransaction(transactionExtention);
+      fail();
+    } catch (Exception e) {
+      assertEquals("keyPair is null", e.getMessage());
+    }
+    Transaction signTransaction = client.signTransaction(transactionExtention, keyPair);
+    assertNotNull(signTransaction);
+
+    // for deployContract, should set privateKey before
+    try {
+      client.deployContract("testDeployContract", "",
+          "bytecode", null, 150_000_000L,
+          0, 1_000_000L,
+          0, null, 0);
+      fail();
+
+    } catch (Exception e) {
+      assertEquals("keyPair is null, should set privateKey", e.getMessage());
+    }
+
+    client.close();
+  }
+
+  @Test
+  void testWithPrivateKey() throws IllegalException {
+    ApiWrapper client = new ApiWrapperBuilder(Constant.FULLNODE_NILE)
+        .withGrpcEndpointSolidity(Constant.FULLNODE_NILE_SOLIDITY)
+        .withPrivateKey(keyPair.toPrivateKey()).build();
+    assertNotNull(client);
+    TransactionExtention transactionExtention
+        = client.transfer(keyPair.toBase58CheckAddress(),
+        KeyPair.generate().toBase58CheckAddress(), 10);
+
+    Transaction signTransaction = client.signTransaction(transactionExtention);
+    assertNotNull(signTransaction);
+
+    client.close();
+  }
+
+  @Test
+  void testPrivateKeyToString() {
+    String result = new ApiWrapperBuilder(Constant.FULLNODE_NILE)
+        .withGrpcEndpointSolidity(Constant.FULLNODE_NILE_SOLIDITY)
+        .withTLS()
+        .withTimeout(2000)
+        .withPrivateKey(keyPair.toPrivateKey()).toString();
+
+    assertFalse(result.contains(keyPair.toPrivateKey()));
+
+  }
+
+}
+
+

--- a/core/src/test/java/org/tron/trident/core/ApiWrapperBuilderFunctionalTest.java
+++ b/core/src/test/java/org/tron/trident/core/ApiWrapperBuilderFunctionalTest.java
@@ -203,18 +203,6 @@ class ApiWrapperBuilderFunctionalTest {
     client.close();
   }
 
-  @Test
-  void testPrivateKeyToString() {
-    String result = new ApiWrapperBuilder(Constant.FULLNODE_NILE)
-        .withGrpcEndpointSolidity(Constant.FULLNODE_NILE_SOLIDITY)
-        .withTLS()
-        .withTimeout(2000)
-        .withPrivateKey(keyPair.toPrivateKey()).toString();
-
-    assertFalse(result.contains(keyPair.toPrivateKey()));
-
-  }
-
 }
 
 

--- a/core/src/test/java/org/tron/trident/core/ApiWrapperBuilderTest.java
+++ b/core/src/test/java/org/tron/trident/core/ApiWrapperBuilderTest.java
@@ -1,0 +1,113 @@
+package org.tron.trident.core;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.tron.trident.core.key.KeyPair;
+
+/**
+ * Unit tests for ApiWrapperBuilder class
+ */
+class ApiWrapperBuilderTest {
+
+  private static final String TEST_PRIVATE_KEY = KeyPair.generate().toPrivateKey();
+  private static final String TEST_API_KEY = "test-api-key-12345";
+  private static final long TEST_TIMEOUT_MS = 5000L;
+
+  @TempDir
+  static Path tempDir;
+
+  private static File testCertFile;
+
+  @BeforeAll
+  static void setUp() throws IOException {
+    // Create a temporary certificate file for TLS testing
+    testCertFile = tempDir.resolve("test-cert.pem").toFile();
+    Files.write(testCertFile.toPath(), ("-----BEGIN CERTIFICATE-----\nTEST "
+        + "CERTIFICATE\n-----END CERTIFICATE-----").getBytes());
+  }
+
+  @Test
+  void testConstructorWithAllParameters() {
+    // Test the main constructor with all three parameters
+    ApiWrapperBuilder builder = new ApiWrapperBuilder(
+        Constant.FULLNODE_NILE,
+        Constant.FULLNODE_NILE_SOLIDITY,
+        TEST_PRIVATE_KEY
+    );
+    assertNotNull(builder);
+    assertEquals(Constant.FULLNODE_NILE, builder.getGrpcEndpoint());
+    assertEquals(Constant.FULLNODE_NILE_SOLIDITY, builder.getGrpcEndpointSolidity());
+    assertEquals(TEST_PRIVATE_KEY, builder.getHexPrivateKey());
+    assertFalse(builder.isUseTLS());
+    assertEquals(0, builder.getInterceptors().size());
+
+    // set tls/ApiKey/Timeout
+    builder = builder.withTLS()
+        .withApiKey(TEST_API_KEY)
+        .withTimeout(TEST_TIMEOUT_MS);
+
+    assertTrue(builder.isUseTLS());
+    assertEquals(2, builder.getInterceptors().size());
+    assertEquals("HeaderAttachingClientInterceptor",
+        builder.getInterceptors().get(0).getClass().getSimpleName());
+    assertEquals("TimeoutInterceptor",
+        builder.getInterceptors().get(1).getClass().getSimpleName());
+
+    // Verify that the builder can be built successfully
+    ApiWrapper wrapper = builder.build();
+    assertNotNull(wrapper);
+    assertNotNull(wrapper.keyPair);
+    assertEquals(TEST_PRIVATE_KEY, wrapper.keyPair.toPrivateKey());
+    wrapper.close();
+
+    // set builder only with grpcEndpoint
+    builder = new ApiWrapperBuilder(
+        Constant.FULLNODE_NILE
+    );
+    assertNotNull(builder);
+    assertEquals(Constant.FULLNODE_NILE, builder.getGrpcEndpoint());
+    assertNull(builder.getGrpcEndpointSolidity());
+    builder = builder.withGrpcEndpointSolidity(Constant.FULLNODE_NILE_SOLIDITY);
+    assertEquals(Constant.FULLNODE_NILE_SOLIDITY, builder.getGrpcEndpointSolidity());
+    builder = builder.withTLS(testCertFile);
+    assertTrue(builder.isUseTLS());
+    assertEquals(testCertFile, builder.getTrustCert());
+  }
+
+  @Test
+  void testConstructorWithNullParameters() {
+    // Test constructor with null parameters
+    assertThrows(IllegalArgumentException.class, () -> {
+      new ApiWrapperBuilder(null,
+          Constant.FULLNODE_NILE_SOLIDITY, TEST_PRIVATE_KEY);
+    });
+
+    assertThrows(IllegalArgumentException.class, () -> {
+      new ApiWrapperBuilder(Constant.FULLNODE_NILE,
+          null, TEST_PRIVATE_KEY);
+    });
+
+    assertThrows(IllegalArgumentException.class, () -> {
+      new ApiWrapperBuilder(Constant.FULLNODE_NILE,
+          Constant.FULLNODE_NILE_SOLIDITY, null);
+    });
+
+    assertThrows(IllegalArgumentException.class, () -> {
+      new ApiWrapperBuilder(Constant.FULLNODE_NILE,
+          Constant.FULLNODE_NILE_SOLIDITY, "123");
+    });
+  }
+
+}

--- a/core/src/test/java/org/tron/trident/core/ApiWrapperBuilderTest.java
+++ b/core/src/test/java/org/tron/trident/core/ApiWrapperBuilderTest.java
@@ -110,4 +110,24 @@ class ApiWrapperBuilderTest {
     });
   }
 
+  @Test
+  void testToString() {
+    ApiWrapperBuilder builder = new ApiWrapperBuilder(
+        Constant.FULLNODE_NILE,
+        Constant.FULLNODE_NILE_SOLIDITY,
+        TEST_PRIVATE_KEY
+    );
+    String toStringResult = builder.toString();
+    assertTrue(toStringResult.contains("grpcEndpoint=" + Constant.FULLNODE_NILE));
+    assertTrue(toStringResult.contains("grpcEndpointSolidity=" + Constant.FULLNODE_NILE_SOLIDITY));
+    assertTrue(toStringResult.contains("hexPrivateKey=****"));
+    assertTrue(toStringResult.contains("useTLS=false"));
+    assertTrue(toStringResult.contains("trustCert=null"));
+
+    builder.withTLS(testCertFile);
+    toStringResult = builder.toString();
+    assertTrue(toStringResult.contains("useTLS=true"));
+    assertTrue(toStringResult.contains("trustCert=" + testCertFile.getAbsolutePath()));
+    }
+
 }


### PR DESCRIPTION
**What does this PR do?**

  - Chainable builder: `withTLS([certFile])`, `withApiKey`, `withTimeout`, `withInterceptors`, `withGrpcEndpointSolidity`, `withPrivateKey`.
  - TLS over gRPC using `io.grpc` `TlsChannelCredentials`, with optional trust certificate; interceptors apply to all channels.
  - Flexible clients: FullNode-only or FullNode+SolidityNode; Solidity calls now error if the Solidity channel is unset/closed; `signTransaction` and `deployContract` require a non-null private key; `close()` is safe when Solidity is absent; builder `toString()` masks private keys; 
  - `ofMainnet`, `ofShasta`, and `ofNile` now build clients via the builder.
  -  All `ApiWrapper` constructors are deprecated; use `new ApiWrapperBuilder(...).build()`.

**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**
Parameter validation at construction is stricter — calls that succeeded on 0.9.x (empty apiKey, null interceptor list, private keys that are not exactly 64 hex chars or carry a `0x` prefix, `timeout <= 0`) now throw `IllegalArgumentException`, including via the `ofMainnet` / `ofNile` / `ofShasta` factories. In addition, the public fields `keyPair`, `channelSolidity` and `blockingStubSolidity` can now be null when no private key / solidity endpoint is configured (they were never null in 0.9.x), so code reading them directly must null-check.