### PR TITLE
fix(core): improve ApiWrapperBuilder API and ApiWrapper construction

### DIFF
--- a/core/src/main/java/org/tron/trident/core/ApiWrapper.java
+++ b/core/src/main/java/org/tron/trident/core/ApiWrapper.java
@@ -145,7 +145,7 @@ import org.tron.trident.utils.Strings;
  * // Full-featured client with both FullNode and SolidityNode access
  * ApiWrapper client = new ApiWrapperBuilder(grpcEndpoint, grpcEndpointSolidity, privateKey)
  *     .withApiKey("your-api-key")       // Optional: set API key for TronGrid
- *     .withTLS()                        // Optional: enable TLS,use withTLS(new File("xxx.crt"))
+ *     .withTLS()                        // Optional: enable TLS, use withTLS(new File("xxx.crt"))
  *     .withTimeout(5000)                // Optional: set request timeout in milliseconds
  *     .build();
  *
@@ -191,21 +191,25 @@ public class ApiWrapper implements Api {
   private long expireTimeStamp = -1;
 
   public ApiWrapper(ApiWrapperBuilder builder) {
+    keyPair = Strings.isEmpty(builder.getHexPrivateKey()) ? null : new KeyPair(
+        builder.getHexPrivateKey());
 
     // Build channels with interceptors and Create stubs
     channel = buildChannel(builder, builder.getGrpcEndpoint());
     blockingStub = WalletGrpc.newBlockingStub(channel);
 
     if (builder.getGrpcEndpointSolidity() != null) {
-      channelSolidity = buildChannel(builder, builder.getGrpcEndpointSolidity());
+      try {
+        channelSolidity = buildChannel(builder, builder.getGrpcEndpointSolidity());
+      } catch (RuntimeException e) {
+        channel.shutdown();
+        throw e;
+      }
       blockingStubSolidity = WalletSolidityGrpc.newBlockingStub(channelSolidity);
     } else {
       channelSolidity = null;
       blockingStubSolidity = null;
     }
-
-    keyPair = Strings.isEmpty(builder.getHexPrivateKey()) ? null : new KeyPair(
-        builder.getHexPrivateKey());
   }
 
   private ManagedChannel buildChannel(ApiWrapperBuilder builder, String target) {
@@ -224,8 +228,9 @@ public class ApiWrapper implements Api {
       }
     }
 
-    if (!builder.getInterceptors().isEmpty()) {
-      channelBuilder.intercept(builder.getInterceptors());
+    List<ClientInterceptor> interceptors = builder.buildInterceptors();
+    if (!interceptors.isEmpty()) {
+      channelBuilder.intercept(interceptors);
     }
     return channelBuilder.build();
   }
@@ -258,7 +263,7 @@ public class ApiWrapper implements Api {
   public ApiWrapper(String grpcEndpoint, String grpcEndpointSolidity, String hexPrivateKey,
                     List<ClientInterceptor> clientInterceptors) {
     this(new ApiWrapperBuilder(grpcEndpoint, grpcEndpointSolidity, hexPrivateKey)
-            .withInterceptors(clientInterceptors));
+            .addInterceptors(clientInterceptors));
   }
 
   /**
@@ -280,7 +285,7 @@ public class ApiWrapper implements Api {
   public ApiWrapper(String grpcEndpoint, String grpcEndpointSolidity, String hexPrivateKey,
                     List<ClientInterceptor> clientInterceptors, int timeout) {
     this(new ApiWrapperBuilder(grpcEndpoint, grpcEndpointSolidity, hexPrivateKey)
-            .withInterceptors(clientInterceptors)
+            .addInterceptors(clientInterceptors)
             .withTimeout(timeout));
   }
 
@@ -459,7 +464,7 @@ public class ApiWrapper implements Api {
     if (this.channelSolidity == null
         || this.channelSolidity.isShutdown()
         || this.channelSolidity.isTerminated()) {
-      throw new IllegalArgumentException("the channelSolidity is null or close");
+      throw new IllegalStateException("the channelSolidity is null or closed");
     }
   }
 
@@ -600,9 +605,8 @@ public class ApiWrapper implements Api {
       }
       solidHeadBlockId = referHeadBlockId;
       transactionExpireTimeStamp = expireTimeStamp;
-    } else if (blockingStubSolidity == null) {
-      throw new RuntimeException("blockingStubSolidity is null");
     } else {
+      checkSolidityChannel();
       BlockReq blockReq = BlockReq.newBuilder().setDetail(false).build();
       BlockExtention solidHeadBlock = blockingStubSolidity.getBlock(blockReq);
       solidHeadBlockId = Utils.getBlockId(solidHeadBlock);
@@ -2269,6 +2273,7 @@ public class ApiWrapper implements Api {
   @Deprecated
   @Override
   public NumberMessage getRewardSolidity(String address) {
+    checkSolidityChannel();
     ByteString bsAddress = parseAddress(address);
     BytesMessage bytesMessage = BytesMessage.newBuilder()
         .setValue(bsAddress)
@@ -2915,6 +2920,7 @@ public class ApiWrapper implements Api {
   @Deprecated
   @Override
   public PricesResponseMessage getBandwidthPricesOnSolidity() {
+    checkSolidityChannel();
     return blockingStubSolidity.getBandwidthPrices(EmptyMessage.getDefaultInstance());
   }
 
@@ -2932,6 +2938,7 @@ public class ApiWrapper implements Api {
   @Deprecated
   @Override
   public PricesResponseMessage getEnergyPricesOnSolidity() {
+    checkSolidityChannel();
     return blockingStubSolidity.getEnergyPrices(EmptyMessage.getDefaultInstance());
   }
 
@@ -3489,9 +3496,7 @@ public class ApiWrapper implements Api {
           .concat(constructorParamsByteString);
       bytecode = ByteArray.toHexString(newByteCode.toByteArray());
     }
-    if (keyPair == null) {
-      throw new IllegalArgumentException("keyPair is null, should set privateKey");
-    }
+    Preconditions.checkArgument(keyPair != null, "keyPair is null, should set privateKey");
     CreateSmartContract createSmartContract = createSmartContract(
         contractName, keyPair.toBase58CheckAddress(), abiStr, bytecode, callValue,
         consumeUserResourcePercent, originEnergyLimit, tokenValue, tokenId);

--- a/core/src/main/java/org/tron/trident/core/ApiWrapper.java
+++ b/core/src/main/java/org/tron/trident/core/ApiWrapper.java
@@ -162,6 +162,8 @@ import org.tron.trident.utils.Strings;
 
 public class ApiWrapper implements Api {
 
+  private static final String KEY_PAIR_NOT_SET = "keyPair is null, should set privateKey";
+
   public final WalletGrpc.WalletBlockingStub blockingStub;
   public final WalletSolidityGrpc.WalletSolidityBlockingStub blockingStubSolidity;
   public final KeyPair keyPair;
@@ -557,11 +559,13 @@ public class ApiWrapper implements Api {
 
   @Override
   public Transaction signTransaction(TransactionExtention txnExt) {
+    Preconditions.checkArgument(keyPair != null, KEY_PAIR_NOT_SET);
     return signTransaction(txnExt, keyPair);
   }
 
   @Override
   public Transaction signTransaction(Transaction txn) {
+    Preconditions.checkArgument(keyPair != null, KEY_PAIR_NOT_SET);
     return signTransaction(txn, keyPair);
   }
 
@@ -3490,13 +3494,13 @@ public class ApiWrapper implements Api {
     validateCallValue(callValue);
     validateTokenId(tokenId);
     validateTokenValue(tokenValue);
+    Preconditions.checkArgument(keyPair != null, KEY_PAIR_NOT_SET);
     if (constructorParams != null && !constructorParams.isEmpty()) {
       ByteString constructorParamsByteString = encodeParameter(constructorParams);
       ByteString newByteCode = ByteString.copyFrom(ByteArray.fromHexString(bytecode))
           .concat(constructorParamsByteString);
       bytecode = ByteArray.toHexString(newByteCode.toByteArray());
     }
-    Preconditions.checkArgument(keyPair != null, "keyPair is null, should set privateKey");
     CreateSmartContract createSmartContract = createSmartContract(
         contractName, keyPair.toBase58CheckAddress(), abiStr, bytecode, callValue,
         consumeUserResourcePercent, originEnergyLimit, tokenValue, tokenId);

--- a/core/src/main/java/org/tron/trident/core/ApiWrapperBuilder.java
+++ b/core/src/main/java/org/tron/trident/core/ApiWrapperBuilder.java
@@ -28,7 +28,7 @@ public class ApiWrapperBuilder {
   @Getter
   private String apiKey;
   @Getter
-  private long timeoutMs; // 0 means no timeout
+  private long timeoutMs; // unset, no timeout interceptor is added
   private final List<ClientInterceptor> customInterceptors = new ArrayList<>();
 
   public ApiWrapperBuilder(String grpcEndpoint, String grpcEndpointSolidity,

--- a/core/src/main/java/org/tron/trident/core/ApiWrapperBuilder.java
+++ b/core/src/main/java/org/tron/trident/core/ApiWrapperBuilder.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 import lombok.Getter;
 import org.tron.trident.core.interceptor.TimeoutInterceptor;
+import org.tron.trident.utils.Numeric;
 import org.tron.trident.utils.Strings;
 
 public class ApiWrapperBuilder {
@@ -24,22 +25,22 @@ public class ApiWrapperBuilder {
   @Getter
   private File trustCert; // Certificate for custom full node
   @Getter
-  private List<ClientInterceptor> interceptors = new ArrayList<>();// Default: no timeout
+  private String apiKey;
+  @Getter
+  private long timeoutMs; // 0 means no timeout
+  @Getter
+  private final List<ClientInterceptor> customInterceptors = new ArrayList<>();
 
   public ApiWrapperBuilder(String grpcEndpoint, String grpcEndpointSolidity,
       String hexPrivateKey) {
-    Preconditions.checkArgument(grpcEndpoint != null, "grpcEndpoint is null");
-    Preconditions.checkArgument(grpcEndpointSolidity != null, "grpcEndpointSolidity is null");
-    Preconditions.checkArgument(hexPrivateKey != null && hexPrivateKey.length() == 64,
-        "hexPrivateKey should be 64 hex characters (32 bytes)");
-
+    Preconditions.checkArgument(!Strings.isEmpty(grpcEndpoint), "grpcEndpoint is null or empty");
     this.grpcEndpoint = grpcEndpoint;
-    this.grpcEndpointSolidity = grpcEndpointSolidity;
-    this.hexPrivateKey = hexPrivateKey;
+    withGrpcEndpointSolidity(grpcEndpointSolidity);
+    withPrivateKey(hexPrivateKey);
   }
 
   public ApiWrapperBuilder(String grpcEndpoint) {
-    Preconditions.checkArgument(grpcEndpoint != null, "grpcEndpoint is null");
+    Preconditions.checkArgument(!Strings.isEmpty(grpcEndpoint), "grpcEndpoint is null or empty");
     this.grpcEndpoint = grpcEndpoint;
   }
 
@@ -55,7 +56,8 @@ public class ApiWrapperBuilder {
    */
   public ApiWrapperBuilder withTLS(File certFile) {
     Preconditions.checkNotNull(certFile, "certFile is null");
-    Preconditions.checkArgument(certFile.exists(), "cert file does not exist: " + certFile.getAbsolutePath());
+    Preconditions.checkArgument(certFile.exists(),
+        "cert file does not exist: " + certFile.getAbsolutePath());
     this.useTLS = true;
     this.trustCert = certFile;
     return this;
@@ -66,6 +68,7 @@ public class ApiWrapperBuilder {
    */
   public ApiWrapperBuilder withTLS() {
     this.useTLS = true;
+    this.trustCert = null;
     return this;
   }
 
@@ -74,11 +77,7 @@ public class ApiWrapperBuilder {
    */
   public ApiWrapperBuilder withApiKey(String apiKey) {
     Preconditions.checkArgument(!Strings.isEmpty(apiKey), "apiKey is empty");
-    Metadata header = new Metadata();
-    Metadata.Key<String> key =
-        Metadata.Key.of("TRON-PRO-API-KEY", Metadata.ASCII_STRING_MARSHALLER);
-    header.put(key, apiKey);
-    interceptors.add(MetadataUtils.newAttachHeadersInterceptor(header));
+    this.apiKey = apiKey;
     return this;
   }
 
@@ -87,16 +86,20 @@ public class ApiWrapperBuilder {
    */
   public ApiWrapperBuilder withTimeout(long timeoutMs) {
     Preconditions.checkArgument(timeoutMs > 0, "timeout should be greater than 0");
-    this.interceptors.add(new TimeoutInterceptor(timeoutMs));
+    this.timeoutMs = timeoutMs;
     return this;
   }
 
   /**
-   * Add multiple custom interceptors
+   * Add multiple custom interceptors. Null elements are ignored.
    */
-  public ApiWrapperBuilder withInterceptors(List<ClientInterceptor> interceptors) {
+  public ApiWrapperBuilder addInterceptors(List<ClientInterceptor> interceptors) {
     Preconditions.checkArgument(interceptors != null, "interceptors is null");
-    this.interceptors.addAll(interceptors);
+    for (ClientInterceptor interceptor : interceptors) {
+      if (interceptor != null) {
+        customInterceptors.add(interceptor);
+      }
+    }
     return this;
   }
 
@@ -104,19 +107,42 @@ public class ApiWrapperBuilder {
    * set grpcEndpointSolidity
    */
   public ApiWrapperBuilder withGrpcEndpointSolidity(String grpcEndpointSolidity) {
-    Preconditions.checkArgument(grpcEndpointSolidity != null, "grpcEndpointSolidity is null");
+    Preconditions.checkArgument(!Strings.isEmpty(grpcEndpointSolidity),
+        "grpcEndpointSolidity is null or empty");
     this.grpcEndpointSolidity = grpcEndpointSolidity;
     return this;
   }
 
   /**
-   * set PrivateKey
+   * set PrivateKey, an optional "0x" prefix is accepted
    */
   public ApiWrapperBuilder withPrivateKey(String hexPrivateKey) {
-    Preconditions.checkArgument(hexPrivateKey != null && hexPrivateKey.length() == 64,
+    String cleaned = Numeric.cleanHexPrefix(hexPrivateKey);
+    Preconditions.checkArgument(cleaned != null && cleaned.length() == 64,
         "hexPrivateKey should be 64 hex characters (32 bytes)");
-    this.hexPrivateKey = hexPrivateKey;
+    this.hexPrivateKey = cleaned;
     return this;
+  }
+
+  /**
+   * Assemble the final interceptor list: TimeoutInterceptor first (innermost, so the
+   * configured deadline is applied last and cannot be overridden by other interceptors,
+   * per gRPC's reverse-order execution), then the API-key header, then custom ones.
+   */
+  List<ClientInterceptor> buildInterceptors() {
+    List<ClientInterceptor> interceptors = new ArrayList<>();
+    if (timeoutMs > 0) {
+      interceptors.add(new TimeoutInterceptor(timeoutMs));
+    }
+    if (!Strings.isEmpty(apiKey)) {
+      Metadata header = new Metadata();
+      Metadata.Key<String> key =
+          Metadata.Key.of("TRON-PRO-API-KEY", Metadata.ASCII_STRING_MARSHALLER);
+      header.put(key, apiKey);
+      interceptors.add(MetadataUtils.newAttachHeadersInterceptor(header));
+    }
+    interceptors.addAll(customInterceptors);
+    return interceptors;
   }
 
   public ApiWrapper build() {
@@ -130,7 +156,9 @@ public class ApiWrapperBuilder {
         .add("hexPrivateKey", hexPrivateKey != null ? "****" : null)
         .add("useTLS", useTLS)
         .add("trustCert", trustCert != null ? trustCert.getAbsolutePath() : null)
-        .add("interceptors", interceptors)
+        .add("apiKey", apiKey != null ? "****" : null)
+        .add("timeoutMs", timeoutMs)
+        .add("customInterceptors", customInterceptors)
         .toString();
   }
 

--- a/core/src/main/java/org/tron/trident/core/ApiWrapperBuilder.java
+++ b/core/src/main/java/org/tron/trident/core/ApiWrapperBuilder.java
@@ -7,6 +7,7 @@ import io.grpc.Metadata;
 import io.grpc.stub.MetadataUtils;
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import lombok.Getter;
 import org.tron.trident.core.interceptor.TimeoutInterceptor;
@@ -28,7 +29,6 @@ public class ApiWrapperBuilder {
   private String apiKey;
   @Getter
   private long timeoutMs; // 0 means no timeout
-  @Getter
   private final List<ClientInterceptor> customInterceptors = new ArrayList<>();
 
   public ApiWrapperBuilder(String grpcEndpoint, String grpcEndpointSolidity,
@@ -64,7 +64,10 @@ public class ApiWrapperBuilder {
   }
 
   /**
-   * Enable TLS
+   * Enable TLS using the system trust certificates.
+   * <p>
+   * A certificate previously set by {@link #withTLS(File)} is cleared.
+   * </p>
    */
   public ApiWrapperBuilder withTLS() {
     this.useTLS = true;
@@ -92,6 +95,10 @@ public class ApiWrapperBuilder {
 
   /**
    * Add multiple custom interceptors. Null elements are ignored.
+   * <p>
+   * Custom interceptors are applied outside the timeout interceptor, so they cannot
+   * change the deadline set by {@link #withTimeout(long)}.
+   * </p>
    */
   public ApiWrapperBuilder addInterceptors(List<ClientInterceptor> interceptors) {
     Preconditions.checkArgument(interceptors != null, "interceptors is null");
@@ -122,6 +129,13 @@ public class ApiWrapperBuilder {
         "hexPrivateKey should be 64 hex characters (32 bytes)");
     this.hexPrivateKey = cleaned;
     return this;
+  }
+
+  /**
+   * The custom interceptors added so far, as an unmodifiable view.
+   */
+  public List<ClientInterceptor> getCustomInterceptors() {
+    return Collections.unmodifiableList(customInterceptors);
   }
 
   /**

--- a/core/src/test/java/org/tron/trident/core/ApiWrapperBuilderFunctionalTest.java
+++ b/core/src/test/java/org/tron/trident/core/ApiWrapperBuilderFunctionalTest.java
@@ -184,6 +184,14 @@ class ApiWrapperBuilderFunctionalTest {
       client.signTransaction(transactionExtention);
       fail();
     } catch (Exception e) {
+      assertEquals("keyPair is null, should set privateKey", e.getMessage());
+    }
+
+    // passing an explicit null keyPair is an argument error, not a missing config
+    try {
+      client.signTransaction(transactionExtention, null);
+      fail();
+    } catch (Exception e) {
       assertEquals("keyPair is null", e.getMessage());
     }
     Transaction signTransaction = client.signTransaction(transactionExtention, keyPair);
@@ -213,6 +221,7 @@ class ApiWrapperBuilderFunctionalTest {
           Constant.FULLNODE_NILE_SOLIDITY, keyPair.toPrivateKey(), null, 5000);
       fail();
     } catch (Exception e) {
+      assertTrue(e instanceof IllegalArgumentException);
       assertEquals("interceptors is null", e.getMessage());
     }
 
@@ -222,6 +231,7 @@ class ApiWrapperBuilderFunctionalTest {
           Constant.FULLNODE_NILE_SOLIDITY, keyPair.toPrivateKey(), "");
       fail();
     } catch (Exception e) {
+      assertTrue(e instanceof IllegalArgumentException);
       assertEquals("apiKey is empty", e.getMessage());
     }
 

--- a/core/src/test/java/org/tron/trident/core/ApiWrapperBuilderFunctionalTest.java
+++ b/core/src/test/java/org/tron/trident/core/ApiWrapperBuilderFunctionalTest.java
@@ -1,7 +1,6 @@
 package org.tron.trident.core;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -63,7 +62,7 @@ class ApiWrapperBuilderFunctionalTest {
       blockExtention = client.getBlock(false, NodeType.SOLIDITY_NODE);
       fail();
     } catch (Exception e) {
-      assertTrue(e instanceof IllegalArgumentException);
+      assertTrue(e instanceof IllegalStateException);
     }
 
     client.close();
@@ -128,7 +127,24 @@ class ApiWrapperBuilderFunctionalTest {
       client.getNowBlockSolidity();
       fail();
     } catch (Exception e) {
-      assertEquals("the channelSolidity is null or close", e.getMessage());
+      assertTrue(e instanceof IllegalStateException);
+      assertEquals("the channelSolidity is null or closed", e.getMessage());
+    }
+
+    try {
+      client.getRewardSolidity(keyPair.toBase58CheckAddress());
+      fail();
+    } catch (Exception e) {
+      assertTrue(e instanceof IllegalStateException);
+      assertEquals("the channelSolidity is null or closed", e.getMessage());
+    }
+
+    try {
+      client.getEnergyPricesOnSolidity();
+      fail();
+    } catch (Exception e) {
+      assertTrue(e instanceof IllegalStateException);
+      assertEquals("the channelSolidity is null or closed", e.getMessage());
     }
 
     BlockExtention blockExtention = client.getBlock(false);
@@ -138,7 +154,8 @@ class ApiWrapperBuilderFunctionalTest {
       client.transfer(keyPair.toBase58CheckAddress(), toAddress, 10);
       fail();
     } catch (Exception e) {
-      assertEquals("createTransactionExtention error,blockingStubSolidity is null", e.getMessage());
+      assertEquals("createTransactionExtention error,the channelSolidity is null or closed",
+          e.getMessage());
     }
 
     client.enableLocalCreate(Utils.getBlockId(blockExtention),
@@ -185,6 +202,34 @@ class ApiWrapperBuilderFunctionalTest {
     }
 
     client.close();
+  }
+
+  @Test
+  @SuppressWarnings("deprecation")
+  void testDeprecatedConstructors() {
+    // a null interceptor list fails fast at construction
+    try {
+      new ApiWrapper(Constant.FULLNODE_NILE,
+          Constant.FULLNODE_NILE_SOLIDITY, keyPair.toPrivateKey(), null, 5000);
+      fail();
+    } catch (Exception e) {
+      assertEquals("interceptors is null", e.getMessage());
+    }
+
+    // an empty apiKey fails fast at construction
+    try {
+      new ApiWrapper(Constant.FULLNODE_NILE,
+          Constant.FULLNODE_NILE_SOLIDITY, keyPair.toPrivateKey(), "");
+      fail();
+    } catch (Exception e) {
+      assertEquals("apiKey is empty", e.getMessage());
+    }
+
+    // "0x"-prefixed keys are accepted
+    ApiWrapper clientPrefixedKey = new ApiWrapper(Constant.FULLNODE_NILE,
+        Constant.FULLNODE_NILE_SOLIDITY, "0x" + keyPair.toPrivateKey());
+    assertEquals(keyPair.toPrivateKey(), clientPrefixedKey.keyPair.toPrivateKey());
+    clientPrefixedKey.close();
   }
 
   @Test

--- a/core/src/test/java/org/tron/trident/core/ApiWrapperBuilderTest.java
+++ b/core/src/test/java/org/tron/trident/core/ApiWrapperBuilderTest.java
@@ -7,13 +7,17 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.grpc.ClientInterceptor;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.tron.trident.core.interceptor.TimeoutInterceptor;
 import org.tron.trident.core.key.KeyPair;
 
 /**
@@ -51,7 +55,8 @@ class ApiWrapperBuilderTest {
     assertEquals(Constant.FULLNODE_NILE_SOLIDITY, builder.getGrpcEndpointSolidity());
     assertEquals(TEST_PRIVATE_KEY, builder.getHexPrivateKey());
     assertFalse(builder.isUseTLS());
-    assertEquals(0, builder.getInterceptors().size());
+    assertEquals(0, builder.getCustomInterceptors().size());
+    assertEquals(0, builder.buildInterceptors().size());
 
     // set tls/ApiKey/Timeout
     builder = builder.withTLS()
@@ -59,11 +64,17 @@ class ApiWrapperBuilderTest {
         .withTimeout(TEST_TIMEOUT_MS);
 
     assertTrue(builder.isUseTLS());
-    assertEquals(2, builder.getInterceptors().size());
-    assertEquals("HeaderAttachingClientInterceptor",
-        builder.getInterceptors().get(0).getClass().getSimpleName());
+    assertEquals(TEST_API_KEY, builder.getApiKey());
+    assertEquals(TEST_TIMEOUT_MS, builder.getTimeoutMs());
+
+    // TimeoutInterceptor is assembled first (innermost) so the configured deadline
+    // cannot be overridden by the API-key header or custom interceptors
+    List<ClientInterceptor> interceptors = builder.buildInterceptors();
+    assertEquals(2, interceptors.size());
     assertEquals("TimeoutInterceptor",
-        builder.getInterceptors().get(1).getClass().getSimpleName());
+        interceptors.get(0).getClass().getSimpleName());
+    assertEquals("HeaderAttachingClientInterceptor",
+        interceptors.get(1).getClass().getSimpleName());
 
     // Verify that the builder can be built successfully
     ApiWrapper wrapper = builder.build();
@@ -84,6 +95,49 @@ class ApiWrapperBuilderTest {
     builder = builder.withTLS(testCertFile);
     assertTrue(builder.isUseTLS());
     assertEquals(testCertFile, builder.getTrustCert());
+  }
+
+  @Test
+  void testPrivateKeyAcceptsHexPrefix() {
+    // "0x"-prefixed keys are accepted and normalized to the plain 64-char form
+    ApiWrapperBuilder builder = new ApiWrapperBuilder(Constant.FULLNODE_NILE)
+        .withPrivateKey("0x" + TEST_PRIVATE_KEY);
+    assertEquals(TEST_PRIVATE_KEY, builder.getHexPrivateKey());
+
+    // too-short keys are rejected
+    assertThrows(IllegalArgumentException.class, () -> {
+      new ApiWrapperBuilder(Constant.FULLNODE_NILE)
+          .withPrivateKey(TEST_PRIVATE_KEY.substring(2));
+    });
+  }
+
+  @Test
+  void testRepeatedSettersLastWins() {
+    ApiWrapperBuilder builder = new ApiWrapperBuilder(Constant.FULLNODE_NILE)
+        .withTimeout(1000L)
+        .withTimeout(TEST_TIMEOUT_MS)
+        .withApiKey("first-key")
+        .withApiKey(TEST_API_KEY);
+
+    assertEquals(TEST_TIMEOUT_MS, builder.getTimeoutMs());
+    assertEquals(TEST_API_KEY, builder.getApiKey());
+    // exactly one TimeoutInterceptor and one header interceptor, not stacked copies
+    assertEquals(2, builder.buildInterceptors().size());
+  }
+
+  @Test
+  void testAddInterceptors() {
+    ClientInterceptor interceptor = new TimeoutInterceptor(1000L);
+    ApiWrapperBuilder builder = new ApiWrapperBuilder(Constant.FULLNODE_NILE)
+        .addInterceptors(Arrays.asList(interceptor, null));
+
+    // null elements are filtered
+    assertEquals(1, builder.getCustomInterceptors().size());
+    assertEquals(1, builder.buildInterceptors().size());
+
+    assertThrows(IllegalArgumentException.class, () -> {
+      new ApiWrapperBuilder(Constant.FULLNODE_NILE).addInterceptors(null);
+    });
   }
 
   @Test
@@ -108,6 +162,15 @@ class ApiWrapperBuilderTest {
       new ApiWrapperBuilder(Constant.FULLNODE_NILE,
           Constant.FULLNODE_NILE_SOLIDITY, "123");
     });
+
+    // empty endpoints are rejected like null ones
+    assertThrows(IllegalArgumentException.class, () -> {
+      new ApiWrapperBuilder("");
+    });
+
+    assertThrows(IllegalArgumentException.class, () -> {
+      new ApiWrapperBuilder(Constant.FULLNODE_NILE).withGrpcEndpointSolidity("");
+    });
   }
 
   @Test
@@ -121,13 +184,17 @@ class ApiWrapperBuilderTest {
     assertTrue(toStringResult.contains("grpcEndpoint=" + Constant.FULLNODE_NILE));
     assertTrue(toStringResult.contains("grpcEndpointSolidity=" + Constant.FULLNODE_NILE_SOLIDITY));
     assertTrue(toStringResult.contains("hexPrivateKey=****"));
+    assertFalse(toStringResult.contains(TEST_PRIVATE_KEY));
     assertTrue(toStringResult.contains("useTLS=false"));
     assertTrue(toStringResult.contains("trustCert=null"));
 
-    builder.withTLS(testCertFile);
+    builder.withTLS(testCertFile).withApiKey(TEST_API_KEY);
     toStringResult = builder.toString();
     assertTrue(toStringResult.contains("useTLS=true"));
     assertTrue(toStringResult.contains("trustCert=" + testCertFile.getAbsolutePath()));
-    }
+    // the API key must never appear in logs
+    assertTrue(toStringResult.contains("apiKey=****"));
+    assertFalse(toStringResult.contains(TEST_API_KEY));
+  }
 
 }

--- a/core/src/test/java/org/tron/trident/core/ApiWrapperBuilderTest.java
+++ b/core/src/test/java/org/tron/trident/core/ApiWrapperBuilderTest.java
@@ -71,10 +71,8 @@ class ApiWrapperBuilderTest {
     // cannot be overridden by the API-key header or custom interceptors
     List<ClientInterceptor> interceptors = builder.buildInterceptors();
     assertEquals(2, interceptors.size());
-    assertEquals("TimeoutInterceptor",
-        interceptors.get(0).getClass().getSimpleName());
-    assertEquals("HeaderAttachingClientInterceptor",
-        interceptors.get(1).getClass().getSimpleName());
+    assertTrue(interceptors.get(0) instanceof TimeoutInterceptor);
+    assertFalse(interceptors.get(1) instanceof TimeoutInterceptor);
 
     // Verify that the builder can be built successfully
     ApiWrapper wrapper = builder.build();
@@ -138,6 +136,25 @@ class ApiWrapperBuilderTest {
     assertThrows(IllegalArgumentException.class, () -> {
       new ApiWrapperBuilder(Constant.FULLNODE_NILE).addInterceptors(null);
     });
+
+    // the getter must not expose the internal list for mutation
+    assertThrows(UnsupportedOperationException.class, () -> {
+      builder.getCustomInterceptors().add(null);
+    });
+  }
+
+  @Test
+  void testWithTlsUsesSystemTrustCerts() {
+    // withTLS() means "system trust certificates", so it clears a custom one
+    ApiWrapperBuilder builder = new ApiWrapperBuilder(Constant.FULLNODE_NILE)
+        .withTLS(testCertFile)
+        .withTLS();
+    assertTrue(builder.isUseTLS());
+    assertNull(builder.getTrustCert());
+
+    // and the reverse order keeps the custom certificate
+    builder.withTLS(testCertFile);
+    assertEquals(testCertFile, builder.getTrustCert());
   }
 
   @Test


### PR DESCRIPTION
**What does this PR do?**

  - `ApiWrapperBuilder`: rename `withInterceptors` to `addInterceptors` — the method appends rather than replaces, and null elements are filtered.
  - `ApiWrapperBuilder`: keep `apiKey` and `timeout` as fields and assemble the interceptor list in `build()`, so repeated calls replace instead of stacking, and the `TimeoutInterceptor` stays innermost — custom interceptors can no longer override the configured deadline.
  - `ApiWrapperBuilder`: `withPrivateKey` accepts an optional `0x` prefix, as `KeyPair` does; empty endpoints are rejected; each field is validated in one place only; `toString()` masks `apiKey` as well as the private key.
  - `ApiWrapper`: parse the private key before creating channels and shut down the FullNode channel when the Solidity channel fails, so a failed construction no longer leaks `ManagedChannel`s.
  - `ApiWrapper`: `checkSolidityChannel` throws `IllegalStateException` instead of `IllegalArgumentException`, and also guards `getRewardSolidity`, `getBandwidthPricesOnSolidity` and `getEnergyPricesOnSolidity`; `createTransaction` reuses it instead of an inline null check with a different exception and message.

**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**
`ApiWrapperBuilder.withInterceptors` is renamed to `addInterceptors`, and the `getInterceptors()` getter is replaced by `getCustomInterceptors()`, which returns an unmodifiable view of the caller-supplied interceptors only — the timeout and API-key interceptors are no longer part of it, since they are assembled in `build()`.