### PR TITLE
fix(abi): prevent decode amplification from aliased tail pointers

### DIFF
--- a/abi/src/main/java/org/tron/trident/abi/DefaultFunctionReturnDecoder.java
+++ b/abi/src/main/java/org/tron/trident/abi/DefaultFunctionReturnDecoder.java
@@ -82,6 +82,20 @@ public class DefaultFunctionReturnDecoder extends FunctionReturnDecoder {
       Utils.validateTypeReferenceDepth(typeReference);
     }
 
+    // Counts the values and payload bytes this result decodes into, to reject a response that
+    // inflates into more than it carries.
+    final boolean outermostDecode = TypeDecoder.beginDecodeLimits(input.length());
+    try {
+      return buildResults(input, outputParameters);
+    } finally {
+      if (outermostDecode) {
+        TypeDecoder.endDecodeLimits();
+      }
+    }
+  }
+
+  private static List<Type> buildResults(
+      String input, List<TypeReference<Type>> outputParameters) {
     List<Type> results = new ArrayList<>(outputParameters.size());
 
     int offset = 0;

--- a/abi/src/main/java/org/tron/trident/abi/TypeDecoder.java
+++ b/abi/src/main/java/org/tron/trident/abi/TypeDecoder.java
@@ -75,15 +75,9 @@ public class TypeDecoder {
    * Limits for the decode in progress, or null when none is:
    * {@code {values, maxValues, payloadHex, maxPayloadHex}}.
    *
-   * <p>Element tail pointers come straight from the input and nothing requires them to be
-   * distinct, so L elements may all name one tail — or overlapping tails — and each decodes
-   * independently while passing a bound measured against the whole remaining input, amplifying
-   * what the response retains in values or in bytes. Both are counted for the whole decode,
-   * against what the response actually carries.
-   *
-   * <p>Held per-thread so the decode signatures stay as they are; the outermost decode seeds
-   * this and clears it on the way out, so nested decodes share one count and a decode that
-   * throws leaves nothing behind on a pooled thread.
+   * <p>Caps how many values and payload bytes one response may decode into, so aliased or
+   * overlapping tail offsets cannot amplify it. Held per-thread; seeded by the function-return
+   * and array entry points and cleared by whichever call opened it.
    */
   private static final ThreadLocal<long[]> DECODE_LIMITS = new ThreadLocal<>();
 
@@ -91,18 +85,16 @@ public class TypeDecoder {
    * Opens limits covering an input of {@code inputLengthHex} hex chars, unless already open.
    * Returns true when this call opened them, in which case the caller closes them in a finally.
    *
-   * <p>The value limit is the input's word count, because every value in a well-formed encoding
-   * owns a word of its own; the byte limit is the input itself, which a well-formed encoding
-   * never spends more of than it carries. Neither leaves room for a shape that decodes the same
-   * bytes twice.
+   * <p>Caps values at the input's word count (rounded up, so a truncated input fails the
+   * later bounds check instead of this cap) and payload at the input length itself.
    */
   static boolean beginDecodeLimits(int inputLengthHex) {
     if (DECODE_LIMITS.get() != null) {
       return false;
     }
-    DECODE_LIMITS.set(
-        new long[] {
-            0L, inputLengthHex / MAX_BYTE_LENGTH_FOR_HEX_STRING, 0L, inputLengthHex});
+    final long maxValues =
+        (long) Math.ceil((double) inputLengthHex / MAX_BYTE_LENGTH_FOR_HEX_STRING);
+    DECODE_LIMITS.set(new long[] {0L, maxValues, 0L, inputLengthHex});
     return true;
   }
 
@@ -119,7 +111,7 @@ public class TypeDecoder {
     if (++limits[0] > limits[1]) {
       throw new IllegalArgumentException(
           "Invalid ABI input: decodes to more values than it can carry (over "
-              + limits[1] + ") — elements share or overlap tail offsets");
+              + limits[1] + ") - elements share or overlap tail offsets");
     }
   }
 
@@ -132,8 +124,8 @@ public class TypeDecoder {
     limits[2] += hexChars;
     if (limits[2] > limits[3]) {
       throw new IllegalArgumentException(
-          "Invalid ABI input: decodes more bytes than it occupies (" + limits[2]
-              + " hex chars of " + limits[3] + ") — elements share or overlap tail offsets");
+          "Invalid ABI input: decodes more than it occupies (" + limits[2]
+              + " of " + limits[3] + " hex chars) - elements share or overlap tail offsets");
     }
   }
 
@@ -187,10 +179,9 @@ public class TypeDecoder {
   @SuppressWarnings("unchecked")
   static <T extends Type> T decode(String input, int offset, Class<T> type) {
     if (!DynamicBytes.class.isAssignableFrom(type)
-        && !Utf8String.class.isAssignableFrom(type)
-        && !Array.class.isAssignableFrom(type)) {
-      // A fixed-width value owns the single word it is read from. Containers own nothing of
-      // their own when they are inline, which is why they are not counted here.
+        && !Utf8String.class.isAssignableFrom(type)) {
+      // A fixed-width value owns the single word it is read from; dynamic bytes and strings
+      // are charged as payload where their length is read.
       countDecodedValue();
     }
     if (NumericType.class.isAssignableFrom(type)) {
@@ -1163,7 +1154,7 @@ public class TypeDecoder {
       TypeReference<T> typeReference,
       int length,
       BiFunction<List<T>, String, T> consumer) {
-    final boolean outermostDecode = beginDecodeLimits(input.length());
+    final boolean outermostDecode = beginDecodeLimits(input.length() - offset);
     try {
       Class<T> cls = Utils.getParameterizedTypeFromArray(typeReference);
       int remainingHex = input.length() - offset;

--- a/abi/src/main/java/org/tron/trident/abi/TypeDecoder.java
+++ b/abi/src/main/java/org/tron/trident/abi/TypeDecoder.java
@@ -71,6 +71,72 @@ public class TypeDecoder {
 
   static final int MAX_BYTE_LENGTH_FOR_HEX_STRING = Type.MAX_BYTE_LENGTH << 1;
 
+  /**
+   * Limits for the decode in progress, or null when none is:
+   * {@code {values, maxValues, payloadHex, maxPayloadHex}}.
+   *
+   * <p>Element tail pointers come straight from the input and nothing requires them to be
+   * distinct, so L elements may all name one tail — or overlapping tails — and each decodes
+   * independently while passing a bound measured against the whole remaining input, amplifying
+   * what the response retains in values or in bytes. Both are counted for the whole decode,
+   * against what the response actually carries.
+   *
+   * <p>Held per-thread so the decode signatures stay as they are; the outermost decode seeds
+   * this and clears it on the way out, so nested decodes share one count and a decode that
+   * throws leaves nothing behind on a pooled thread.
+   */
+  private static final ThreadLocal<long[]> DECODE_LIMITS = new ThreadLocal<>();
+
+  /**
+   * Opens limits covering an input of {@code inputLengthHex} hex chars, unless already open.
+   * Returns true when this call opened them, in which case the caller closes them in a finally.
+   *
+   * <p>The value limit is the input's word count, because every value in a well-formed encoding
+   * owns a word of its own; the byte limit is the input itself, which a well-formed encoding
+   * never spends more of than it carries. Neither leaves room for a shape that decodes the same
+   * bytes twice.
+   */
+  static boolean beginDecodeLimits(int inputLengthHex) {
+    if (DECODE_LIMITS.get() != null) {
+      return false;
+    }
+    DECODE_LIMITS.set(
+        new long[] {
+            0L, inputLengthHex / MAX_BYTE_LENGTH_FOR_HEX_STRING, 0L, inputLengthHex});
+    return true;
+  }
+
+  static void endDecodeLimits() {
+    DECODE_LIMITS.remove();
+  }
+
+  /** Counts one word-owning value: a fixed-width value, or an element's tail head slot. */
+  private static void countDecodedValue() {
+    final long[] limits = DECODE_LIMITS.get();
+    if (limits == null) {
+      return;
+    }
+    if (++limits[0] > limits[1]) {
+      throw new IllegalArgumentException(
+          "Invalid ABI input: decodes to more values than it can carry (over "
+              + limits[1] + ") — elements share or overlap tail offsets");
+    }
+  }
+
+  /** Counts the input a dynamic payload accounts for, in hex chars. */
+  private static void countDecodedPayload(long hexChars) {
+    final long[] limits = DECODE_LIMITS.get();
+    if (limits == null) {
+      return;
+    }
+    limits[2] += hexChars;
+    if (limits[2] > limits[3]) {
+      throw new IllegalArgumentException(
+          "Invalid ABI input: decodes more bytes than it occupies (" + limits[2]
+              + " hex chars of " + limits[3] + ") — elements share or overlap tail offsets");
+    }
+  }
+
   public static Type instantiateType(String solidityType, Object value)
       throws InvocationTargetException,
       NoSuchMethodException,
@@ -120,6 +186,13 @@ public class TypeDecoder {
 
   @SuppressWarnings("unchecked")
   static <T extends Type> T decode(String input, int offset, Class<T> type) {
+    if (!DynamicBytes.class.isAssignableFrom(type)
+        && !Utf8String.class.isAssignableFrom(type)
+        && !Array.class.isAssignableFrom(type)) {
+      // A fixed-width value owns the single word it is read from. Containers own nothing of
+      // their own when they are inline, which is why they are not counted here.
+      countDecodedValue();
+    }
     if (NumericType.class.isAssignableFrom(type)) {
       return (T) decodeNumeric(
           input.substring(
@@ -329,7 +402,9 @@ public class TypeDecoder {
   static int decodeUintAsInt(String rawInput, int offset) {
     checkWindowBounds(rawInput.length(), offset, MAX_BYTE_LENGTH_FOR_HEX_STRING);
     String input = rawInput.substring(offset, offset + MAX_BYTE_LENGTH_FOR_HEX_STRING);
-    BigInteger value = decode(input, 0, Uint.class).getValue();
+    // decodeNumeric rather than decode: a length or offset word is structure, not a decoded
+    // value, and counting it would charge the same word twice.
+    BigInteger value = decodeNumeric(input, Uint.class).getValue();
     if (value.bitLength() > 31) {
       throw new IllegalArgumentException(
           "Invalid ABI uint " + value + " exceeds Integer.MAX_VALUE");
@@ -382,6 +457,12 @@ public class TypeDecoder {
       throw new IllegalArgumentException(
           "Invalid ABI dynamic bytes length: " + encodedLength);
     }
+
+    // The length word plus the payload padded to whole words: what a well-formed encoding
+    // spends here.
+    countDecodedPayload(
+        (1 + (long) Math.ceil((double) encodedLength / Type.MAX_BYTE_LENGTH))
+            * MAX_BYTE_LENGTH_FOR_HEX_STRING);
 
     int hexStringEncodedLength = encodedLength << 1;
     String data = input.substring(valueOffset, valueOffset + hexStringEncodedLength);
@@ -657,6 +738,7 @@ public class TypeDecoder {
       final int beginIndex = offset + tracker.staticOffset;
       if (isDynamic(innerType)) {
         checkWindowBounds(input.length(), beginIndex, MAX_BYTE_LENGTH_FOR_HEX_STRING);
+        countDecodedValue();
         final int parameterOffset =
             decodeDynamicStructDynamicParameterOffset(
                 input.substring(beginIndex, beginIndex + 64))
@@ -758,6 +840,7 @@ public class TypeDecoder {
         final int beginIndex = offset + staticOffset;
         if (isDynamicStructField(constructor, i)) {
           checkWindowBounds(input.length(), beginIndex, MAX_BYTE_LENGTH_FOR_HEX_STRING);
+          countDecodedValue();
           final int parameterOffset =
               decodeDynamicStructDynamicParameterOffset(
                   input.substring(beginIndex, beginIndex + 64))
@@ -1062,12 +1145,25 @@ public class TypeDecoder {
     return (int) nextOffset;
   }
 
+  /**
+   * Resolves an element's tail pointer and counts the head slot that element owns. Counting per
+   * dereference is what makes an aliased tail cost again on every element naming it, and it
+   * covers elements holding nothing countable of their own — an empty nested array owns its
+   * head slot even though it materialises no values.
+   */
+  private static int countedDataOffset(
+      String input, int offset, TypeReference<?> typeReference) throws ClassNotFoundException {
+    countDecodedValue();
+    return getDataOffset(input, offset, typeReference);
+  }
+
   private static <T extends Type> T decodeArrayElements(
       String input,
       int offset,
       TypeReference<T> typeReference,
       int length,
       BiFunction<List<T>, String, T> consumer) {
+    final boolean outermostDecode = beginDecodeLimits(input.length());
     try {
       Class<T> cls = Utils.getParameterizedTypeFromArray(typeReference);
       int remainingHex = input.length() - offset;
@@ -1092,7 +1188,7 @@ public class TypeDecoder {
               value =
                   TypeDecoder.decodeDynamicStruct(
                       input,
-                      offset + getDataOffset(input, currOffset, typeReference),
+                      offset + countedDataOffset(input, currOffset, typeReference),
                       (TypeReference<T>) new TypeReference<DynamicStruct>(
                           typeReference.isIndexed(),
                           typeReference.getSubTypeReference().getInnerTypes()) {});
@@ -1107,7 +1203,7 @@ public class TypeDecoder {
                   TypeDecoder.decodeDynamicStruct(
                       input,
                       offset
-                          + getDataOffset(
+                          + countedDataOffset(
                           input, currOffset, typeReference),
                       TypeReference.create(cls));
               currOffset = advanceArrayElementOffset(
@@ -1161,7 +1257,7 @@ public class TypeDecoder {
                     TypeDecoder.decodeDynamicArray(
                         input,
                         offset
-                            + getDataOffset(
+                            + countedDataOffset(
                             input, currOffset, typeReference),
                         dynamicTypeRef);
             currOffset = advanceArrayElementOffset(
@@ -1223,7 +1319,7 @@ public class TypeDecoder {
               // outer container stores an offset pointer (1 slot); actual data
               // is at offset + pointerValue, in head/tail form.
               int hexStringDataOffset =
-                  getDataOffset(input, currOffset, staticReference);
+                  countedDataOffset(input, currOffset, staticReference);
               value =
                   (T)
                       TypeDecoder.decodeStaticArray(
@@ -1254,7 +1350,7 @@ public class TypeDecoder {
         for (int i = 0; i < length; i++) {
           T value;
           if (isDynamic(cls)) {
-            int hexStringDataOffset = getDataOffset(input, currOffset, typeReference);
+            int hexStringDataOffset = countedDataOffset(input, currOffset, typeReference);
             value = decode(input, offset + hexStringDataOffset, cls);
             currOffset += MAX_BYTE_LENGTH_FOR_HEX_STRING;
           } else {
@@ -1278,6 +1374,10 @@ public class TypeDecoder {
           "Unable to access parameterized type "
               + Utils.getTypeName(typeReference.getType()),
           e);
+    } finally {
+      if (outermostDecode) {
+        endDecodeLimits();
+      }
     }
   }
 }

--- a/abi/src/test/java/org/tron/trident/abi/TypeDecoderAmplificationTest.java
+++ b/abi/src/test/java/org/tron/trident/abi/TypeDecoderAmplificationTest.java
@@ -55,7 +55,7 @@ public class TypeDecoderAmplificationTest {
   private static final int WORD = 64;
 
   private static final String TOO_MANY_VALUES = "more values than it can carry";
-  private static final String TOO_MANY_BYTES = "more bytes than it occupies";
+  private static final String TOO_MANY_BYTES = "more than it occupies";
 
   /**
    * Asserts the decode is rejected, and rejected by the accounting rather than incidentally.

--- a/abi/src/test/java/org/tron/trident/abi/TypeDecoderAmplificationTest.java
+++ b/abi/src/test/java/org/tron/trident/abi/TypeDecoderAmplificationTest.java
@@ -1,0 +1,667 @@
+/*
+ * Copyright 2019 Web3 Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package org.tron.trident.abi;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+import org.tron.trident.abi.datatypes.DynamicArray;
+import org.tron.trident.abi.datatypes.DynamicBytes;
+import org.tron.trident.abi.datatypes.DynamicStruct;
+import org.tron.trident.abi.datatypes.Type;
+import org.tron.trident.abi.datatypes.Utf8String;
+import org.tron.trident.abi.datatypes.generated.StaticArray20;
+import org.tron.trident.abi.datatypes.generated.Uint256;
+
+/**
+ * Regression tests for decode amplification: a well-formed ABI payload never decodes to more
+ * values, or more bytes, than it physically carries, so an array element must not be able to
+ * claim input another element already claimed.
+ *
+ * <p>Each element of a dynamic array carries its own tail pointer, read from attacker-controlled
+ * input, and nothing requires those pointers to be distinct. Every pointer may name the same
+ * tail — or overlapping tails — and each element then decodes independently while passing a
+ * bound measured against the <em>whole</em> remaining input.
+ *
+ * <p>The shapes below inflate in one of two directions, and each is caught by its own count.
+ * A few elements sharing one large payload inflate bytes while the value count stays low;
+ * many elements sharing an empty container do the reverse. Both kinds are represented here,
+ * alongside legitimate encodings that must keep decoding.
+ */
+public class TypeDecoderAmplificationTest {
+
+  /** Hex characters per 32-byte ABI word. */
+  private static final int WORD = 64;
+
+  private static final String TOO_MANY_VALUES = "more values than it can carry";
+  private static final String TOO_MANY_BYTES = "more bytes than it occupies";
+
+  /**
+   * Asserts the decode is rejected, and rejected by the accounting rather than incidentally.
+   * Bounds checks raise the same exception type, so a payload with a construction mistake could
+   * otherwise pass the test while never exercising the amplification it is meant to cover.
+   */
+  private static void assertRejected(String expectedReason, Executable decode) {
+    IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, decode);
+    assertTrue(
+        thrown.getMessage().contains(expectedReason),
+        "rejected for the wrong reason: " + thrown.getMessage());
+  }
+
+  /** Left-pads {@code value} into a single 32-byte ABI word. Locale-independent. */
+  private static String word(long value) {
+    String hex = Long.toHexString(value);
+    StringBuilder sb = new StringBuilder(WORD);
+    for (int i = hex.length(); i < WORD; i++) {
+      sb.append('0');
+    }
+    return sb.append(hex).toString();
+  }
+
+  private static String zeros(int hexChars) {
+    StringBuilder sb = new StringBuilder(hexChars);
+    for (int i = 0; i < hexChars; i++) {
+      sb.append('0');
+    }
+    return sb.toString();
+  }
+
+  /**
+   * Byte offset that a head slot must carry for its element data to land at
+   * {@code targetHex}. Element pointers are relative to the start of the head region, which
+   * begins one word after the array-length prefix.
+   */
+  private static long pointerTo(int targetHex) {
+    return (targetHex - WORD) / 2;
+  }
+
+  // ---------------------------------------------------------------------------------------
+  // Aliased tails: every element points at one shared payload.
+  // ---------------------------------------------------------------------------------------
+
+  /**
+   * {@code string[]} whose every head slot names one shared tail: ~4 KB of input that decodes
+   * into 64 independent 2 KB strings, a shape that scales quadratically.
+   */
+  private static String aliasedStringTailPayload() {
+    final int elements = 64;
+    final int payloadBytes = 2048;
+    final int tailHex = WORD + elements * WORD;
+
+    StringBuilder input = new StringBuilder();
+    input.append(word(elements));
+    for (int i = 0; i < elements; i++) {
+      input.append(word(pointerTo(tailHex)));
+    }
+    input.append(word(payloadBytes));
+    input.append(zeros(payloadBytes * 2));
+    return input.toString();
+  }
+
+  @Test
+  public void decodeDynamicArray_rejectsAliasedStringTails() {
+    String malicious = aliasedStringTailPayload();
+    assertRejected(
+        TOO_MANY_BYTES,
+        () -> TypeDecoder.decodeDynamicArray(
+            malicious, 0, new TypeReference<DynamicArray<Utf8String>>() {}));
+  }
+
+  @Test
+  public void decodeDynamicArray_rejectsAliasedBytesTails() {
+    // The same shape down the DynamicBytes arm of the value dispatch: bytes[] is named in the
+    // report alongside string[], and the two are separate branches in decode().
+    String malicious = aliasedStringTailPayload();
+    assertRejected(
+        TOO_MANY_BYTES,
+        () -> TypeDecoder.decodeDynamicArray(
+            malicious, 0, new TypeReference<DynamicArray<DynamicBytes>>() {}));
+  }
+
+  @Test
+  public void decodeDynamicArray_rejectsAliasedNestedArrayTails() {
+    final int outerElements = 32;
+    final int innerElements = 64;
+    final int tailHex = WORD + outerElements * WORD;
+
+    StringBuilder input = new StringBuilder();
+    input.append(word(outerElements));
+    for (int i = 0; i < outerElements; i++) {
+      input.append(word(pointerTo(tailHex)));
+    }
+    input.append(word(innerElements));
+    for (int i = 0; i < innerElements; i++) {
+      input.append(word(i));
+    }
+
+    // Object-count amplification rather than byte amplification: 32 x 64 = 2048
+    // Uint256 instances materialise from ~3 KB of input.
+    String malicious = input.toString();
+    assertRejected(
+        TOO_MANY_VALUES,
+        () -> TypeDecoder.decodeDynamicArray(
+            malicious, 0, new TypeReference<DynamicArray<DynamicArray<Uint256>>>() {}));
+  }
+
+  // ---------------------------------------------------------------------------------------
+  // Overlapping tails: pointers strictly increase, so a monotonicity-only check accepts
+  // them, but each element's payload still runs over its neighbours'.
+  // ---------------------------------------------------------------------------------------
+
+  @Test
+  public void decodeDynamicArray_rejectsOverlappingStringTails() {
+    final int elements = 64;
+    final int fillerHex = 4096;
+    final int tailHex = WORD + elements * WORD;
+    final int totalHex = tailHex + elements * WORD + fillerHex;
+
+    StringBuilder head = new StringBuilder();
+    head.append(word(elements));
+    StringBuilder tail = new StringBuilder();
+    for (int i = 0; i < elements; i++) {
+      int lengthWordHex = tailHex + i * WORD;
+      head.append(word(pointerTo(lengthWordHex)));
+      // Claim every byte left after this element's own length word: the maximum the
+      // existing whole-input bound allows, which makes all payloads overlap.
+      tail.append(word((totalHex - (lengthWordHex + WORD)) / 2));
+    }
+
+    String malicious = head.append(tail).append(zeros(fillerHex)).toString();
+    assertEquals(totalHex, malicious.length());
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> TypeDecoder.decodeDynamicArray(
+            malicious, 0, new TypeReference<DynamicArray<Utf8String>>() {}));
+  }
+
+  @Test
+  public void decodeDynamicArray_rejectsOverlappingNestedArrayTails() {
+    final int outerElements = 32;
+    final int fillerHex = 4096;
+    final int tailHex = WORD + outerElements * WORD;
+    final int totalHex = tailHex + outerElements * WORD + fillerHex;
+
+    StringBuilder head = new StringBuilder();
+    head.append(word(outerElements));
+    StringBuilder tail = new StringBuilder();
+    for (int i = 0; i < outerElements; i++) {
+      int lengthWordHex = tailHex + i * WORD;
+      head.append(word(pointerTo(lengthWordHex)));
+      // Each inner array declares as many elements as the whole remaining input can
+      // hold, so the inner element runs read straight through their neighbours.
+      tail.append(word((totalHex - (lengthWordHex + WORD)) / WORD));
+    }
+
+    // This is the case that survives if only the payload-length bound is narrowed:
+    // the amplification is carried by the array-length bound instead.
+    String malicious = head.append(tail).append(zeros(fillerHex)).toString();
+    assertEquals(totalHex, malicious.length());
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> TypeDecoder.decodeDynamicArray(
+            malicious, 0, new TypeReference<DynamicArray<DynamicArray<Uint256>>>() {}));
+  }
+
+  // ---------------------------------------------------------------------------------------
+  // Aliased dynamic structs: the amplification rides on the struct's static fields, which
+  // cost the attacker one word each but are decoded afresh for every aliased element.
+  // ---------------------------------------------------------------------------------------
+
+  @Test
+  public void decodeDynamicArray_rejectsAliasedDynamicStructTails() throws Exception {
+    final int elements = 100;
+    final int staticFields = 100;
+    final int tailHex = WORD + elements * WORD;
+
+    List<TypeReference<?>> innerTypes = new ArrayList<TypeReference<?>>();
+    for (int i = 0; i < staticFields; i++) {
+      innerTypes.add(TypeReference.makeTypeReference("uint256"));
+    }
+    // One cheap dynamic field: it makes the struct ABI-dynamic (so the array is head/tail
+    // addressed and can be aliased) while costing a single zero-length word.
+    innerTypes.add(TypeReference.makeTypeReference("uint256[]"));
+    final TypeReference<DynamicStruct> structRef =
+        new TypeReference<DynamicStruct>(false, innerTypes) {};
+
+    StringBuilder input = new StringBuilder();
+    input.append(word(elements));
+    for (int i = 0; i < elements; i++) {
+      input.append(word(pointerTo(tailHex)));
+    }
+    for (int i = 0; i < staticFields; i++) {
+      input.append(word(i));
+    }
+    // Offset of the struct's dynamic field, relative to the start of the struct.
+    input.append(word((staticFields + 1) * (WORD / 2)));
+    input.append(word(0));
+
+    // 203 words in, 100 x 101 = 10 100 objects out if the struct body is not charged.
+    String malicious = input.toString();
+    assertEquals((1 + elements + staticFields + 2) * WORD, malicious.length());
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> TypeDecoder.decodeDynamicArray(
+            malicious,
+            0,
+            new TypeReference<DynamicArray<DynamicStruct>>() {
+              @Override
+              public TypeReference getSubTypeReference() {
+                return structRef;
+              }
+            }));
+  }
+
+  @Test
+  public void decodeDynamicArray_rejectsAliasedEmptyNestedArrays() {
+    final int outer = 100;
+    final int middle = 100;
+
+    StringBuilder input = new StringBuilder();
+    input.append(word(outer));
+    for (int i = 0; i < outer; i++) {
+      input.append(word(outer * (WORD / 2)));
+    }
+    input.append(word(middle));
+    for (int i = 0; i < middle; i++) {
+      input.append(word(middle * (WORD / 2)));
+    }
+    input.append(word(0));
+
+    // Nothing chargeable lives at the leaves — the innermost array is empty — so the whole
+    // amplification is carried by the element containers themselves: 203 words in, 10 100
+    // arrays out unless each tail dereference is paid for.
+    String malicious = input.toString();
+    assertEquals((1 + outer + 1 + middle + 1) * WORD, malicious.length());
+    assertRejected(
+        TOO_MANY_VALUES,
+        () -> TypeDecoder.decodeDynamicArray(
+            malicious,
+            0,
+            new TypeReference<DynamicArray<DynamicArray<DynamicArray<Uint256>>>>() {}));
+  }
+
+  // ---------------------------------------------------------------------------------------
+  // Partitioning the tails is not enough on its own: an element's inline reads have to respect
+  // the region it was given, or it simply reads on into the next element's slots.
+  // ---------------------------------------------------------------------------------------
+
+  @Test
+  public void decodeDynamicArray_rejectsStructHeadsReadingSharedSlots() throws Exception {
+    final int elements = 100;
+    final int staticFields = 100;
+    final int headEnd = WORD + elements * WORD;
+
+    List<TypeReference<?>> innerTypes = new ArrayList<TypeReference<?>>();
+    for (int i = 0; i < staticFields; i++) {
+      innerTypes.add(TypeReference.makeTypeReference("uint256"));
+    }
+    innerTypes.add(TypeReference.makeTypeReference("uint256[]"));
+    final TypeReference<DynamicStruct> structRef =
+        new TypeReference<DynamicStruct>(false, innerTypes) {};
+
+    StringBuilder input = new StringBuilder();
+    input.append(word(elements));
+    for (int i = 0; i < elements; i++) {
+      // Tails are distinct and one word apart, so they survive any check on the pointers
+      // themselves — the amplification is in each struct's head reading the next struct's
+      // slots, so one run of static words is decoded once per element.
+      input.append(word(pointerTo(headEnd + i * WORD)));
+    }
+    // An all-zero tail region: every struct's trailing dynamic field then carries offset 0,
+    // pointing back at its own first word, which reads as a zero-length array. Nothing here
+    // is out of bounds; only the static head words are re-read by element after element.
+    for (int i = 0; i < (elements - 1) + (staticFields + 1); i++) {
+      input.append(word(0));
+    }
+
+    // 301 words in, 100 x 101 = 10 100 values out if each struct head is not paid for.
+    String malicious = input.toString();
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> TypeDecoder.decodeDynamicArray(
+            malicious,
+            0,
+            new TypeReference<DynamicArray<DynamicStruct>>() {
+              @Override
+              public TypeReference getSubTypeReference() {
+                return structRef;
+              }
+            }));
+  }
+
+  @Test
+  public void decodeDynamicArray_rejectsWideStaticElementsReadingSharedSlots() {
+    final int outer = 20;
+    final int inner = 20;
+    final int elementWords = 20;
+    final int headEnd = WORD + outer * WORD;
+    // Inner arrays sit one element-count apart, so each has room for its length word plus one
+    // word per element — while every element is in fact 20 words wide and reads on into its
+    // neighbours.
+    final int span = (1 + inner) * WORD;
+
+    StringBuilder input = new StringBuilder();
+    input.append(word(outer));
+    for (int i = 0; i < outer; i++) {
+      input.append(word(pointerTo(headEnd + i * span)));
+    }
+    for (int i = 0; i < outer; i++) {
+      input.append(word(inner));
+      for (int j = 0; j < inner; j++) {
+        input.append(word(j));
+      }
+    }
+    for (int i = 0; i < inner * elementWords; i++) {
+      input.append(word(1));
+    }
+
+    // 20 x 20 x 20 = 8 000 numeric values from 841 words.
+    String malicious = input.toString();
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> TypeDecoder.decodeDynamicArray(
+            malicious,
+            0,
+            new TypeReference<DynamicArray<DynamicArray<StaticArray20<Uint256>>>>() {}));
+  }
+
+  // ---------------------------------------------------------------------------------------
+  // One response, many output parameters: the count has to span the whole function result, or
+  // each output starts fresh and they can all claim the same tail.
+  // ---------------------------------------------------------------------------------------
+
+  @Test
+  public void functionReturnDecoder_rejectsTailsAliasedAcrossOutputParameters() {
+    final int outputs = 40;
+    final int elements = 50;
+
+    List<TypeReference<Type>> outputParameters = new ArrayList<TypeReference<Type>>();
+    StringBuilder input = new StringBuilder();
+    for (int i = 0; i < outputs; i++) {
+      outputParameters.add(
+          (TypeReference<Type>) (TypeReference<?>) new TypeReference<DynamicArray<Uint256>>() {});
+      // Every output head names the same, perfectly well-formed, uint256[] tail.
+      input.append(word(outputs * (WORD / 2)));
+    }
+    input.append(word(elements));
+    for (int i = 0; i < elements; i++) {
+      input.append(word(i));
+    }
+
+    // 91 words in, 40 x 50 = 2 000 Uint256 out while every individual output looks legitimate.
+    String malicious = input.toString();
+    assertEquals((outputs + 1 + elements) * WORD, malicious.length());
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> FunctionReturnDecoder.decode(malicious, outputParameters));
+  }
+
+  // ---------------------------------------------------------------------------------------
+  // Legitimate encodings must keep decoding — these guard against over-tightening.
+  // ---------------------------------------------------------------------------------------
+
+  @Test
+  public void decodeDynamicArray_acceptsLegitimateStringArray() {
+    List<Utf8String> values =
+        Arrays.asList(
+            new Utf8String("alpha"),
+            new Utf8String(""),
+            new Utf8String(
+                "a string comfortably longer than a single 32-byte word, spanning several"));
+    String encoded =
+        TypeEncoder.encode(new DynamicArray<Utf8String>(Utf8String.class, values));
+
+    DynamicArray<Utf8String> decoded =
+        TypeDecoder.decodeDynamicArray(
+            encoded, 0, new TypeReference<DynamicArray<Utf8String>>() {});
+
+    assertEquals(3, decoded.getValue().size());
+    assertEquals("alpha", decoded.getValue().get(0).getValue());
+    assertEquals("", decoded.getValue().get(1).getValue());
+    assertEquals(values.get(2).getValue(), decoded.getValue().get(2).getValue());
+  }
+
+  @Test
+  public void decodeDynamicArray_acceptsLegitimateArrayWithRepeatedValues() {
+    // Equal values still get their own tails; nothing here may look like aliasing.
+    List<Utf8String> values =
+        Arrays.asList(new Utf8String("same"), new Utf8String("same"), new Utf8String("same"));
+    String encoded =
+        TypeEncoder.encode(new DynamicArray<Utf8String>(Utf8String.class, values));
+
+    DynamicArray<Utf8String> decoded =
+        TypeDecoder.decodeDynamicArray(
+            encoded, 0, new TypeReference<DynamicArray<Utf8String>>() {});
+
+    assertEquals(3, decoded.getValue().size());
+    for (int i = 0; i < 3; i++) {
+      assertEquals("same", decoded.getValue().get(i).getValue());
+    }
+  }
+
+  @Test
+  public void decodeDynamicArray_acceptsLegitimateEmptyStringElements() {
+    // Empty payloads make consecutive tails only one word apart — the tightest
+    // legitimate spacing there is.
+    List<Utf8String> values =
+        Arrays.asList(new Utf8String(""), new Utf8String(""), new Utf8String(""));
+    String encoded =
+        TypeEncoder.encode(new DynamicArray<Utf8String>(Utf8String.class, values));
+
+    DynamicArray<Utf8String> decoded =
+        TypeDecoder.decodeDynamicArray(
+            encoded, 0, new TypeReference<DynamicArray<Utf8String>>() {});
+
+    assertEquals(3, decoded.getValue().size());
+    assertEquals("", decoded.getValue().get(2).getValue());
+  }
+
+  @Test
+  public void decodeDynamicArray_acceptsLegitimateEmptyStringArray() {
+    // The tightest legitimate shape there is. Every element costs one head slot and one
+    // zero-length word, so the count lands closer to its limit here than anywhere else — this
+    // is what would break first if anything were ever counted twice.
+    List<Utf8String> values = new ArrayList<Utf8String>();
+    for (int i = 0; i < 64; i++) {
+      values.add(new Utf8String(""));
+    }
+    String encoded =
+        TypeEncoder.encode(new DynamicArray<Utf8String>(Utf8String.class, values));
+
+    DynamicArray<Utf8String> decoded =
+        TypeDecoder.decodeDynamicArray(
+            encoded, 0, new TypeReference<DynamicArray<Utf8String>>() {});
+
+    assertEquals(64, decoded.getValue().size());
+    assertEquals("", decoded.getValue().get(63).getValue());
+  }
+
+  @Test
+  public void decodeDynamicArray_acceptsLegitimateDynamicStructArray() throws Exception {
+    // The malicious struct shapes above are the ones most at risk of over-tightening, so the
+    // ordinary case needs to be pinned too.
+    DynamicStruct first =
+        new DynamicStruct(new Uint256(BigInteger.ONE), new Utf8String("alpha"));
+    DynamicStruct second =
+        new DynamicStruct(new Uint256(BigInteger.TEN), new Utf8String("beta"));
+    String encoded =
+        TypeEncoder.encode(new DynamicArray(DynamicStruct.class, Arrays.asList(first, second)));
+
+    final TypeReference<DynamicStruct> structRef =
+        new TypeReference<DynamicStruct>(
+            false,
+            Arrays.<TypeReference<?>>asList(
+                TypeReference.makeTypeReference("uint256"),
+                TypeReference.makeTypeReference("string"))) {};
+    DynamicArray<DynamicStruct> decoded =
+        TypeDecoder.decodeDynamicArray(
+            encoded,
+            0,
+            new TypeReference<DynamicArray<DynamicStruct>>() {
+              @Override
+              public TypeReference getSubTypeReference() {
+                return structRef;
+              }
+            });
+
+    assertEquals(2, decoded.getValue().size());
+    assertEquals(
+        BigInteger.ONE, decoded.getValue().get(0).getValue().get(0).getValue());
+    assertEquals("beta", decoded.getValue().get(1).getValue().get(1).getValue());
+  }
+
+  @Test
+  public void decodeDynamicArray_acceptsLegitimateLargeStringArray() {
+    List<Utf8String> values = new ArrayList<Utf8String>();
+    for (int i = 0; i < 64; i++) {
+      values.add(new Utf8String("element-" + i));
+    }
+    String encoded =
+        TypeEncoder.encode(new DynamicArray<Utf8String>(Utf8String.class, values));
+
+    DynamicArray<Utf8String> decoded =
+        TypeDecoder.decodeDynamicArray(
+            encoded, 0, new TypeReference<DynamicArray<Utf8String>>() {});
+
+    assertEquals(64, decoded.getValue().size());
+    assertEquals("element-0", decoded.getValue().get(0).getValue());
+    assertEquals("element-63", decoded.getValue().get(63).getValue());
+  }
+
+  @Test
+  public void decodeDynamicArray_acceptsLegitimateNestedUintArray() {
+    List<DynamicArray<Uint256>> outer = new ArrayList<DynamicArray<Uint256>>();
+    outer.add(
+        new DynamicArray<Uint256>(
+            Uint256.class,
+            Arrays.asList(new Uint256(BigInteger.ONE), new Uint256(BigInteger.TEN))));
+    outer.add(
+        new DynamicArray<Uint256>(
+            Uint256.class, Arrays.asList(new Uint256(BigInteger.valueOf(7)))));
+
+    String encoded =
+        TypeEncoder.encode(
+            new DynamicArray(DynamicArray.class, outer));
+
+    DynamicArray<DynamicArray<Uint256>> decoded =
+        TypeDecoder.decodeDynamicArray(
+            encoded, 0, new TypeReference<DynamicArray<DynamicArray<Uint256>>>() {});
+
+    assertEquals(2, decoded.getValue().size());
+    assertEquals(2, decoded.getValue().get(0).getValue().size());
+    assertEquals(1, decoded.getValue().get(1).getValue().size());
+    assertEquals(BigInteger.TEN, decoded.getValue().get(0).getValue().get(1).getValue());
+  }
+
+  // ---------------------------------------------------------------------------------------
+  // Accounting is per decode, never per thread: SDK callers run on pooled threads, so a count
+  // left behind by one request would silently reject the next one to reuse that thread.
+  // These pin the "always cleared, even when the decode aborts" invariant.
+  // ---------------------------------------------------------------------------------------
+
+  /** A legitimate 64-element {@code string[]} that spends most of what its input carries. */
+  private static void decodeLegitimateArray() {
+    List<Utf8String> values = new ArrayList<Utf8String>();
+    for (int i = 0; i < 64; i++) {
+      values.add(new Utf8String("element-" + i));
+    }
+    String encoded =
+        TypeEncoder.encode(new DynamicArray<Utf8String>(Utf8String.class, values));
+    DynamicArray<Utf8String> decoded =
+        TypeDecoder.decodeDynamicArray(
+            encoded, 0, new TypeReference<DynamicArray<Utf8String>>() {});
+    assertEquals(64, decoded.getValue().size());
+  }
+
+  @Test
+  public void repeatedDecodesOnOneThreadDoNotAccumulate() {
+    // Anything carried over from the previous decode would make this one look over-spent.
+    for (int i = 0; i < 5; i++) {
+      decodeLegitimateArray();
+    }
+  }
+
+  @Test
+  public void rejectedDecodeLeavesNothingBehindOnTheThread() {
+    // The dangerous ordering: a decode aborts part-way, then the same thread serves the
+    // next request. Interleaved so a leak shows up on the very next decode.
+    String malicious = aliasedStringTailPayload();
+    for (int i = 0; i < 3; i++) {
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> TypeDecoder.decodeDynamicArray(
+              malicious, 0, new TypeReference<DynamicArray<Utf8String>>() {}));
+      decodeLegitimateArray();
+    }
+  }
+
+  @Test
+  public void pooledThreadIsNotPoisonedByAnEarlierRejection() throws Exception {
+    // Two "requests" forced onto one pooled thread, the first one rejected.
+    ExecutorService pool = Executors.newSingleThreadExecutor();
+    try {
+      final String malicious = aliasedStringTailPayload();
+      pool.submit(
+          () -> {
+            assertThrows(
+                IllegalArgumentException.class,
+                () -> TypeDecoder.decodeDynamicArray(
+                    malicious, 0, new TypeReference<DynamicArray<Utf8String>>() {}));
+            return null;
+          })
+          .get();
+      pool.submit(
+          () -> {
+            decodeLegitimateArray();
+            return null;
+          })
+          .get();
+    } finally {
+      pool.shutdownNow();
+    }
+  }
+
+  @Test
+  public void concurrentDecodesDoNotInterfere() throws Exception {
+    final int threads = 8;
+    ExecutorService pool = Executors.newFixedThreadPool(threads);
+    try {
+      List<Future<?>> futures = new ArrayList<Future<?>>();
+      for (int i = 0; i < threads * 8; i++) {
+        futures.add(
+            pool.submit(
+                () -> {
+                  decodeLegitimateArray();
+                  return null;
+                }));
+      }
+      for (Future<?> future : futures) {
+        // Rethrows whatever the worker threw, so shared state surfaces as a failure here.
+        future.get();
+      }
+    } finally {
+      pool.shutdownNow();
+    }
+  }
+}


### PR DESCRIPTION
**What does this PR do?**

- **`TypeDecoder`**: count what a decode produces against what the response carries, and
  reject when either count is exceeded:
  - dynamic payload bytes → against the input's byte length
  - decoded values → against the input's word count

  A value owns a word when it is fixed-width, or when it is reached through a tail
  pointer, so an aliased tail is paid for again by every element naming it. Inline
  containers own nothing, and length/offset words are structure rather than values.
- **`DefaultFunctionReturnDecoder`**: open one count for the whole function result, so
  outputs decoded one at a time cannot each claim the same tail.
- Counts are per-thread and cleared on the way out, including when the decode throws.
  No existing method signature or visibility is changed.

**Why are these changes required?**

An array's element count and every element's tail pointer are read straight from the
response, and nothing required those tails to be distinct. The two existing guards were
per-element and each measured against the *whole* remaining input, so L elements could
all name one tail — or overlapping tails — and each passed its own check while
allocating independently. A few hundred words of input then decode into tens of
thousands of objects, and the shape scales with the response, so a single hostile
`constantResult` can exhaust the heap of any process embedding the SDK. Reachable
whenever an output is declared as an array of a dynamic element type — `string[]`,
`bytes[]`, `uint256[][]`, or an array of dynamic structs.

**This PR has been tested by:**

- Unit Tests

**Follow up**

**Extra details**
